### PR TITLE
Update static type scale

### DIFF
--- a/packages/@luke-ui/react/src/tokens/values.ts
+++ b/packages/@luke-ui/react/src/tokens/values.ts
@@ -48,15 +48,15 @@ export const fontSizeValues = {
 	small: { unit: 'px', value: 14 },
 	standard: { unit: 'px', value: 16 },
 	medium: { unit: 'px', value: 20 },
-	large: { unit: 'px', value: 40 },
-	xlarge: { unit: 'px', value: 48 },
-	xxlarge: { unit: 'px', value: 55 },
-	h1: { unit: 'px', value: 36 },
-	h2: { unit: 'px', value: 28 },
-	h3: { unit: 'px', value: 24 },
+	large: { unit: 'px', value: 25 },
+	xlarge: { unit: 'px', value: 31 },
+	xxlarge: { unit: 'px', value: 39 },
+	h1: { unit: 'px', value: 39 },
+	h2: { unit: 'px', value: 31 },
+	h3: { unit: 'px', value: 25 },
 	h4: { unit: 'px', value: 20 },
-	h5: { unit: 'px', value: 18 },
-	h6: { unit: 'px', value: 16 },
+	h5: { unit: 'px', value: 16 },
+	h6: { unit: 'px', value: 14 },
 } as const satisfies Record<string, DimensionTokenValue>;
 
 export const fontWeightValues = {


### PR DESCRIPTION
## Summary

- Updates the static font-size token ladder to remove the large jump from `medium` to `large`.
- Reuses the same static ladder for heading tokens instead of keeping a separate ad-hoc heading scale.
- Keeps the existing Capsize-based typography path unchanged; this PR does not add fluid typography or `clamp()` tokens.

## Validation

- `pnpm --filter @luke-ui/react build`
- `pnpm --filter @luke-ui/react check:types`
- `pnpm --filter @luke-ui/react test`

Note: `pnpm --filter @luke-ui/react check:format` reported ignored visual-test screenshot metadata under `screenshots/*.argos.json`; the committed source diff is one TypeScript file and `git diff --check` passes.