### PR TITLE
refactor: centralize package docs catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ packages/@luke-ui/react/src/generated/icons.tsx
 public/dist/
 server/dist/
 storybook-static/
+.worktrees/

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,7 +18,8 @@
 		"preview": "vite preview",
 		"routes:generate": "tsr generate",
 		"routes:watch": "tsr watch",
-		"start": "serve .output/public"
+		"start": "serve .output/public",
+		"test": "vitest run --config vitest.config.ts"
 	},
 	"dependencies": {
 		"@fumadocs/story": "0.0.14",
@@ -48,6 +49,7 @@
 		"nitro": "npm:nitro-nightly@3.0.1-20260128-211656-ae83c97e",
 		"serve": "^14.2.6",
 		"tailwindcss": "^4.2.4",
-		"typescript": "^6.0.3"
+		"typescript": "^6.0.3",
+		"vitest": "catalog:"
 	}
 }

--- a/apps/docs/src/lib/markdown-url.test.ts
+++ b/apps/docs/src/lib/markdown-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { mapPublicToInternal, withBasePath } from './markdown-url';
+
+describe('markdown-url', () => {
+	it('keeps docs markdown URLs on the same public route under a base path', () => {
+		expect(withBasePath('/docs/components/actions/button.md', '/luke-ui/')).toBe(
+			'/luke-ui/docs/components/actions/button.md',
+		);
+	});
+
+	it('rewrites base-prefixed docs markdown URLs to the internal renderer route', () => {
+		expect(mapPublicToInternal('/luke-ui/docs/components/actions/button.md', '/luke-ui/')).toBe(
+			'/markdown/components/actions/button',
+		);
+	});
+});

--- a/apps/docs/src/lib/markdown-url.ts
+++ b/apps/docs/src/lib/markdown-url.ts
@@ -1,20 +1,26 @@
 const DOCS_MARKDOWN_PREFIX = '/docs/';
 const DOCS_MARKDOWN_SUFFIX = '.md';
-const INTERNAL_MARKDOWN_PREFIX = '/llms.mdx/';
+const INTERNAL_MARKDOWN_PREFIX = '/markdown/';
 
 export function toPublic(slug: string): string {
 	return slug === 'index' ? '/docs.md' : `${DOCS_MARKDOWN_PREFIX}${slug}${DOCS_MARKDOWN_SUFFIX}`;
 }
 
-export function toInternal(publicPath: string): string | null {
-	const slug = publicToSlug(publicPath);
+export function withBasePath(publicPath: string, basePath: string): string {
+	if (basePath === '/' || basePath === '') return publicPath;
+	const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}/`;
+	return `${normalizedBase}${publicPath.replace(/^\//, '')}`;
+}
+
+export function toInternal(publicPath: string, basePath = '/'): string | null {
+	const slug = publicToSlug(publicPath, basePath);
 	return slug ? `${INTERNAL_MARKDOWN_PREFIX}${slug}` : null;
 }
 
-export function mapPublicToInternal(url: string | undefined): string | null {
+export function mapPublicToInternal(url: string | undefined, basePath = '/'): string | null {
 	if (!url) return null;
 	const [pathname, suffix = ''] = url.split(/(?=[?#])/);
-	const internalPath = toInternal(pathname ?? '');
+	const internalPath = toInternal(pathname ?? '', basePath);
 	return internalPath ? `${internalPath}${suffix}` : null;
 }
 
@@ -22,9 +28,18 @@ export function internalSegmentsToSourceSlugs(segments: Array<string>): Array<st
 	return segments.length === 1 && segments[0] === 'index' ? [] : segments;
 }
 
-function publicToSlug(publicPath: string): string | null {
-	if (publicPath === '/docs.md') return 'index';
-	if (!publicPath.startsWith(DOCS_MARKDOWN_PREFIX)) return null;
-	if (!publicPath.endsWith(DOCS_MARKDOWN_SUFFIX)) return null;
-	return publicPath.slice(DOCS_MARKDOWN_PREFIX.length, -DOCS_MARKDOWN_SUFFIX.length);
+function publicToSlug(publicPath: string, basePath: string): string | null {
+	const path = stripBasePath(publicPath, basePath);
+	if (path === '/docs.md') return 'index';
+	if (!path.startsWith(DOCS_MARKDOWN_PREFIX)) return null;
+	if (!path.endsWith(DOCS_MARKDOWN_SUFFIX)) return null;
+	return path.slice(DOCS_MARKDOWN_PREFIX.length, -DOCS_MARKDOWN_SUFFIX.length);
+}
+
+function stripBasePath(path: string, basePath: string): string {
+	if (basePath === '/' || basePath === '') return path;
+	const normalizedBase = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
+	if (path === normalizedBase) return '/';
+	if (!path.startsWith(`${normalizedBase}/`)) return path;
+	return path.slice(normalizedBase.length);
 }

--- a/apps/docs/src/package-docs.d.ts
+++ b/apps/docs/src/package-docs.d.ts
@@ -1,3 +1,6 @@
 declare module 'virtual:package-docs' {
+	export const packageDocsCatalog: Array<
+		import('@luke-ui/docs-tools/package-docs-catalog').PackageDocsCatalogMetadata
+	>;
 	export const packageDocs: Record<string, string>;
 }

--- a/apps/docs/src/package-docs.d.ts
+++ b/apps/docs/src/package-docs.d.ts
@@ -1,6 +1,6 @@
 declare module 'virtual:package-docs' {
-	export const packageDocsCatalog: Array<
-		import('@luke-ui/docs-tools/package-docs-catalog').PackageDocsCatalogMetadata
-	>;
+	import type { PackageDocsCatalogMetadata } from '@luke-ui/docs-tools/package-docs-catalog';
+
+	export const packageDocsCatalog: Array<PackageDocsCatalogMetadata>;
 	export const packageDocs: Record<string, string>;
 }

--- a/apps/docs/src/routes/docs/$.tsx
+++ b/apps/docs/src/routes/docs/$.tsx
@@ -12,6 +12,7 @@ import { Suspense } from 'react';
 import browserCollections from '../../../.source/browser';
 import { PageActions } from '../../components/page-actions';
 import { baseOptions } from '../../lib/layout.shared';
+import { withBasePath } from '../../lib/markdown-url';
 import { source } from '../../lib/source';
 import { getStoryPayloads } from '../../lib/story';
 
@@ -57,7 +58,7 @@ const loader = createServerFn({
 
 		return {
 			githubUrl: `${GITHUB_DOCS_URL}/${page.path}`,
-			markdownUrl: `${page.url}.md`,
+			markdownUrl: withBasePath(`${page.url}.md`, import.meta.env.BASE_URL),
 			pageTree: await source.serializePageTree(source.getPageTree()),
 			path: page.path,
 			storyPayloads: await getStoryPayloads(stories),

--- a/apps/docs/src/routes/llms[.]txt.ts
+++ b/apps/docs/src/routes/llms[.]txt.ts
@@ -1,4 +1,4 @@
-import { discoverExports } from '@luke-ui/docs-tools/discover-exports';
+import { packageDocsCatalog } from 'virtual:package-docs';
 import { renderIndex } from '@luke-ui/docs-tools/render-index';
 import { createFileRoute } from '@tanstack/react-router';
 import packageJson from '../../../../packages/@luke-ui/react/package.json' with { type: 'json' };
@@ -9,17 +9,17 @@ export const Route = createFileRoute('/llms.txt')({
 	server: {
 		handlers: {
 			GET: () => {
-				const entries = discoverExports(packageJson.exports);
 				const pageHrefBySlug = new Map(
 					source.getPages().map((page) => [page.slugs.at(-1), `.${page.url}.md`]),
 				);
-				const entriesWithHref = entries.map((entry) => {
-					return Object.assign(entry, {
+				const entriesWithHref = packageDocsCatalog.map((entry) => {
+					return {
+						...entry,
 						href:
 							entry.shape === 'barrel'
 								? `.${toPublic(entry.slug)}`
 								: (pageHrefBySlug.get(entry.slug) ?? `./${entry.slug}.md`),
-					});
+					};
 				});
 
 				const txt = renderIndex({

--- a/apps/docs/src/routes/llms[.]txt.ts
+++ b/apps/docs/src/routes/llms[.]txt.ts
@@ -13,13 +13,12 @@ export const Route = createFileRoute('/llms.txt')({
 					source.getPages().map((page) => [page.slugs.at(-1), `.${page.url}.md`]),
 				);
 				const entriesWithHref = packageDocsCatalog.map((entry) => {
-					return {
-						...entry,
+					return Object.assign({}, entry, {
 						href:
 							entry.shape === 'barrel'
 								? `.${toPublic(entry.slug)}`
 								: (pageHrefBySlug.get(entry.slug) ?? `./${entry.slug}.md`),
-					};
+					});
 				});
 
 				const txt = renderIndex({

--- a/apps/docs/src/routes/markdown/$.ts
+++ b/apps/docs/src/routes/markdown/$.ts
@@ -4,8 +4,8 @@ import { getLLMText } from '../../lib/get-llm-text';
 import { internalSegmentsToSourceSlugs } from '../../lib/markdown-url';
 import { source } from '../../lib/source';
 
-// Internal route used to prerender the public Markdown files.
-export const Route = createFileRoute('/llms.mdx/$')({
+// Internal route used to serve and prerender the public Markdown files.
+export const Route = createFileRoute('/markdown/$')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -1,7 +1,11 @@
 import { spawn } from 'node:child_process';
 import { join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { discoverExports } from '@luke-ui/docs-tools/discover-exports';
+import type {
+	PackageDocsCatalogEntry,
+	PackageDocsCatalogMetadata,
+} from '@luke-ui/docs-tools/package-docs-catalog';
+import { resolvePackageDocsCatalog } from '@luke-ui/docs-tools/package-docs-catalog';
 import tailwindcss from '@tailwindcss/vite';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import react from '@vitejs/plugin-react';
@@ -81,14 +85,43 @@ const packageDocsDir = fileURLToPath(
 // route serves these to AI agents fetching `.mdx` URLs. We can't read them via
 // `import.meta.glob` because `fumadocs-mdx/vite` compiles any `.md`/`.mdx` it
 // sees into a React component, even with the `?raw` query.
-function packageDocsPlugin(): Plugin {
+function packageDocsPlugin(catalog: Array<PackageDocsCatalogEntry>): Plugin {
 	const id = 'virtual:package-docs';
 	const resolved = `\0${id}`;
+	const metadata: Array<PackageDocsCatalogMetadata> = catalog.map((entry) => ({
+		path: entry.path,
+		target: entry.target,
+		slug: entry.slug,
+		shape: entry.shape,
+		pageKind: entry.pageKind,
+		tier: entry.tier,
+		title: entry.title,
+		description: entry.description,
+	}));
 	return {
+		enforce: 'pre',
+		async load(loadId) {
+			if (loadId !== resolved) return null;
+			const entries = await Promise.all(
+				catalog
+					.filter((entry) => entry.pageKind !== 'asset')
+					.map(
+						async (entry) =>
+							[
+								entry.slug,
+								await readFile(join(packageDocsDir, `${entry.slug}.md`), 'utf8'),
+							] as const,
+					),
+			);
+			return [
+				`export const packageDocsCatalog = ${JSON.stringify(metadata)};`,
+				`export const packageDocs = ${JSON.stringify(Object.fromEntries(entries))};`,
+			].join('\n');
+		},
 		configureServer(server) {
 			server.watcher.add(packageDocsDir);
 			const handle = (filePath: string) => {
-				if (!filePath.endsWith('.mdx') || !filePath.startsWith(packageDocsDir)) return;
+				if (!filePath.endsWith('.md') || !filePath.startsWith(packageDocsDir)) return;
 				const mod = server.moduleGraph.getModuleById(resolved);
 				if (mod) {
 					server.moduleGraph.invalidateModule(mod);
@@ -99,21 +132,6 @@ function packageDocsPlugin(): Plugin {
 			server.watcher.on('change', handle);
 			server.watcher.on('unlink', handle);
 		},
-		enforce: 'pre',
-		async load(loadId) {
-			if (loadId !== resolved) return null;
-			const filenames = (await readdir(packageDocsDir)).filter((n) => n.endsWith('.mdx'));
-			const entries = await Promise.all(
-				filenames.map(
-					async (filename) =>
-						[
-							filename.slice(0, -'.mdx'.length),
-							await readFile(join(packageDocsDir, filename), 'utf8'),
-						] as const,
-				),
-			);
-			return `export const packageDocs = ${JSON.stringify(Object.fromEntries(entries))};`;
-		},
 		name: 'package-docs',
 		resolveId(source) {
 			return source === id ? resolved : null;
@@ -121,9 +139,9 @@ function packageDocsPlugin(): Plugin {
 	};
 }
 
-async function getMarkdownPrerenderPages(): Promise<
-	Array<{ path: string; prerender: { outputPath: string } }>
-> {
+async function getMarkdownPrerenderPages(
+	catalog: Array<PackageDocsCatalogEntry>,
+): Promise<Array<{ path: string; prerender: { outputPath: string } }>> {
 	const contentPages = (await findMdxFiles(contentDocsDir)).map((filePath) => {
 		const publicPath = getPublicMarkdownPath(filePath);
 		const internalPath = toInternal(publicPath);
@@ -133,7 +151,7 @@ async function getMarkdownPrerenderPages(): Promise<
 			prerender: { outputPath: publicPath },
 		};
 	});
-	const packagePages = discoverExports(packageJson.exports).flatMap((entry) => {
+	const packagePages = catalog.flatMap((entry) => {
 		if (entry.shape !== 'barrel') return [];
 		return [
 			{
@@ -254,7 +272,11 @@ function packageSourceWatcherPlugin(): Plugin {
 }
 
 export default defineConfig(async () => {
-	const markdownPrerenderPages = await getMarkdownPrerenderPages();
+	const packageDocsCatalog = resolvePackageDocsCatalog({
+		packageRoot: packageRootDir,
+		exportsField: packageJson.exports,
+	});
+	const markdownPrerenderPages = await getMarkdownPrerenderPages(packageDocsCatalog);
 
 	return {
 		// Allow overriding the base URL for deployments to sub-paths (e.g. GitHub Pages).
@@ -288,7 +310,7 @@ export default defineConfig(async () => {
 			storySourcePathPlugin(),
 			staticFunctionBasePathPlugin(),
 			markdownRewritePlugin(),
-			packageDocsPlugin(),
+			packageDocsPlugin(packageDocsCatalog),
 			packageSourceWatcherPlugin(),
 			mdx(await import('./source.config')),
 			tailwindcss(),

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -58,14 +58,14 @@ function markdownRewritePlugin(): Plugin {
 	return {
 		configurePreviewServer(server) {
 			server.middlewares.use((req, _res, next) => {
-				const rewritten = mapPublicToInternal(req.url);
+				const rewritten = mapPublicToInternal(req.url, server.config.base);
 				if (rewritten) req.url = rewritten;
 				next();
 			});
 		},
 		configureServer(server) {
 			server.middlewares.use((req, _res, next) => {
-				const rewritten = mapPublicToInternal(req.url);
+				const rewritten = mapPublicToInternal(req.url, server.config.base);
 				if (rewritten) req.url = rewritten;
 				next();
 			});
@@ -81,8 +81,8 @@ const packageDocsDir = fileURLToPath(
 	new URL('../../packages/@luke-ui/react/docs/', import.meta.url),
 );
 
-// Expose generated package docs as `virtual:package-docs`. The `/llms.mdx/$`
-// route serves these to AI agents fetching `.mdx` URLs. We can't read them via
+// Expose generated package docs as `virtual:package-docs`. The `/markdown/$`
+// routes serve these to AI agents fetching public `.md` URLs. We can't read them via
 // `import.meta.glob` because `fumadocs-mdx/vite` compiles any `.md`/`.mdx` it
 // sees into a React component, even with the `?raw` query.
 function packageDocsPlugin(catalog: Array<PackageDocsCatalogEntry>): Plugin {

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['src/**/*.test.ts'],
+	},
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"fix:unused": "knip --fix",
 		"generate:component": "pnpm --filter=@luke-ui/turbo-generators run generate:component",
 		"release": "turbo run build --filter=docs^... && changeset publish",
-		"test": "turbo run test --filter=@luke-ui/react",
+		"test": "turbo run test",
 		"version-packages": "changeset version"
 	},
 	"devDependencies": {

--- a/packages/@luke-ui/docs-tools/package.json
+++ b/packages/@luke-ui/docs-tools/package.json
@@ -5,10 +5,12 @@
 	"type": "module",
 	"exports": {
 		"./discover-exports": "./src/discover-exports.ts",
+		"./package-docs-catalog": "./src/package-docs-catalog.ts",
 		"./parse-types": "./src/parse-types.ts",
 		"./render-index": "./src/render-index.ts",
+		"./render-page": "./src/render-page.ts",
 		"./render-llms-full": "./src/render-llms-full.ts",
-		"./render-page": "./src/render-page.ts"
+		"./title": "./src/title.ts"
 	},
 	"scripts": {
 		"check:format": "pnpm exec oxfmt -c ../../../.oxfmtrc.json --check .",

--- a/packages/@luke-ui/docs-tools/src/__tests__/fixtures/sample-package/src/sample/index.tsx
+++ b/packages/@luke-ui/docs-tools/src/__tests__/fixtures/sample-package/src/sample/index.tsx
@@ -1,0 +1,16 @@
+import type { JSX } from 'react';
+
+/**
+ * Props for a sample atom.
+ *
+ * @tier atom
+ */
+export interface SampleProps {
+	/** Visible label. */
+	label: string;
+}
+
+/** Sample atom description. */
+export function Sample(props: SampleProps): JSX.Element {
+	return <div>{props.label}</div>;
+}

--- a/packages/@luke-ui/docs-tools/src/__tests__/package-docs-catalog.test.ts
+++ b/packages/@luke-ui/docs-tools/src/__tests__/package-docs-catalog.test.ts
@@ -1,0 +1,71 @@
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { resolvePackageDocsCatalog } from '../package-docs-catalog.js';
+
+const packageRoot = fileURLToPath(new URL('./fixtures/sample-package/', import.meta.url));
+
+describe('resolvePackageDocsCatalog', () => {
+	it('resolves final metadata and parsed data for every export', () => {
+		const catalog = resolvePackageDocsCatalog({
+			packageRoot,
+			exportsField: {
+				'./sample': './dist/sample/index.js',
+				'./kit/primitive': './dist/kit/primitive/index.js',
+				'./stylesheet.css': './dist/stylesheet.css',
+			},
+		});
+
+		const component = catalog.find((entry) => entry.path === './sample');
+		expect(component).toMatchObject({
+			path: './sample',
+			shape: 'component',
+			pageKind: 'component',
+			tier: 'atom',
+			title: 'Sample',
+			description: 'Sample atom description.',
+			sourcePath: expect.stringContaining('/src/sample/index.tsx'),
+			parsed: {
+				componentName: 'Sample',
+			},
+		});
+
+		const primitiveKit = catalog.find((entry) => entry.path === './kit/primitive');
+		expect(primitiveKit).toMatchObject({
+			shape: 'component',
+			pageKind: 'barrel',
+			tier: 'primitive',
+			title: 'Kit (primitive)',
+			sourcePath: expect.stringContaining('/src/kit/primitive/index.tsx'),
+			parsed: {
+				exports: expect.arrayContaining([
+					expect.objectContaining({ name: 'KitControl' }),
+					expect.objectContaining({ name: 'KitItem' }),
+				]),
+			},
+		});
+
+		const asset = catalog.find((entry) => entry.path === './stylesheet.css');
+		expect(asset).toMatchObject({
+			shape: 'asset',
+			pageKind: 'asset',
+			tier: 'n/a',
+			title: 'Stylesheet',
+			description: '',
+		});
+		expect(asset).not.toHaveProperty('sourcePath');
+		expect(asset).not.toHaveProperty('parsed');
+	});
+
+	it('throws with the export path and target when a non-asset source is missing', () => {
+		expect(() =>
+			resolvePackageDocsCatalog({
+				packageRoot,
+				exportsField: {
+					'./missing': './dist/missing/index.js',
+				},
+			}),
+		).toThrow(
+			'Could not resolve source for package export "./missing" targeting "./dist/missing/index.js".',
+		);
+	});
+});

--- a/packages/@luke-ui/docs-tools/src/__tests__/render-index.test.ts
+++ b/packages/@luke-ui/docs-tools/src/__tests__/render-index.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import type { DiscoveredExport } from '../discover-exports.js';
+import type { PackageDocsCatalogMetadata } from '../package-docs-catalog.js';
 import { renderIndex } from '../render-index.js';
 
-const sampleEntries: Array<DiscoveredExport & { description?: string }> = [
+const sampleEntries: Array<PackageDocsCatalogMetadata> = [
 	{
 		description: 'Composed button.',
 		pageKind: 'component',
@@ -11,6 +11,7 @@ const sampleEntries: Array<DiscoveredExport & { description?: string }> = [
 		slug: 'button',
 		target: '',
 		tier: 'composed',
+		title: 'Button',
 	},
 	{
 		description: 'Bare button.',
@@ -20,6 +21,7 @@ const sampleEntries: Array<DiscoveredExport & { description?: string }> = [
 		slug: 'button-primitive',
 		target: '',
 		tier: 'primitive',
+		title: 'Button (primitive)',
 	},
 	{
 		description: 'Design tokens.',
@@ -29,18 +31,32 @@ const sampleEntries: Array<DiscoveredExport & { description?: string }> = [
 		slug: 'tokens',
 		target: '',
 		tier: 'n/a',
+		title: 'Tokens',
 	},
 	{
+		description: '',
 		pageKind: 'asset',
 		path: './stylesheet.css',
 		shape: 'asset',
 		slug: 'stylesheet',
 		target: '',
 		tier: 'n/a',
+		title: 'Stylesheet',
 	},
 ];
 
 describe('renderIndex', () => {
+	it('uses resolved catalog titles directly', () => {
+		const out = renderIndex({
+			entries: sampleEntries.map((entry) =>
+				entry.slug === 'button' ? { ...entry, title: 'Resolved Button' } : entry,
+			),
+			includeLibraryAuthors: false,
+			packageName: '@luke-ui/react',
+		});
+		expect(out).toMatch(/- \[Resolved Button\]\(\.\/button\.md\)/);
+	});
+
 	it('lists composed components in the primary section', () => {
 		const out = renderIndex({
 			entries: sampleEntries,
@@ -84,7 +100,7 @@ describe('renderIndex', () => {
 		const out = renderIndex({
 			entries: sampleEntries.map((entry) =>
 				entry.slug === 'button'
-					? Object.assign(entry, { href: './llms.mdx/docs/components/actions/button.md' })
+					? { ...entry, href: './llms.mdx/docs/components/actions/button.md' }
 					: entry,
 			),
 			includeLibraryAuthors: false,

--- a/packages/@luke-ui/docs-tools/src/__tests__/render-index.test.ts
+++ b/packages/@luke-ui/docs-tools/src/__tests__/render-index.test.ts
@@ -99,14 +99,12 @@ describe('renderIndex', () => {
 	it('uses entry href when provided', () => {
 		const out = renderIndex({
 			entries: sampleEntries.map((entry) =>
-				entry.slug === 'button'
-					? { ...entry, href: './llms.mdx/docs/components/actions/button.md' }
-					: entry,
+				entry.slug === 'button' ? { ...entry, href: './docs/components/actions/button.md' } : entry,
 			),
 			includeLibraryAuthors: false,
 			packageName: '@luke-ui/react',
 		});
-		expect(out).toMatch(/\[Button\]\(\.\/llms\.mdx\/docs\/components\/actions\/button\.md\)/);
+		expect(out).toMatch(/\[Button\]\(\.\/docs\/components\/actions\/button\.md\)/);
 		expect(out).toMatch(/\[Tokens\]\(\.\/tokens\.md\)/);
 	});
 });

--- a/packages/@luke-ui/docs-tools/src/__tests__/render-llms-full.test.ts
+++ b/packages/@luke-ui/docs-tools/src/__tests__/render-llms-full.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import type { LlmsFullEntry } from '../render-llms-full.js';
+import type { PackageDocsCatalogMetadata } from '../package-docs-catalog.js';
 import { renderLlmsFull, sortLlmsFullEntries } from '../render-llms-full.js';
+
+type LlmsFullFixture = Pick<PackageDocsCatalogMetadata, 'slug' | 'shape' | 'tier'> & {
+	md: string;
+};
 
 const md = (slug: string): string => `# ${slug}\nbody-${slug}`;
 
 describe('sortLlmsFullEntries', () => {
 	it('orders atoms → composed → barrels → primitives, each alphabetical by slug', () => {
-		const entries: Array<LlmsFullEntry> = [
+		const entries: Array<LlmsFullFixture> = [
 			// Deliberately mixed and non-alphabetic insertion order.
 			{
 				md: md('combobox-field-primitive'),
@@ -45,9 +49,9 @@ describe('sortLlmsFullEntries', () => {
 	});
 
 	it('drops entries that do not belong to a bucket (assets, unknown tiers)', () => {
-		const entries: Array<LlmsFullEntry> = [
-			{ md: md('stylesheet'), shape: 'asset', slug: 'stylesheet', tier: 'n/a' },
-			{ md: md('button'), shape: 'component', slug: 'button', tier: 'composed' },
+		const entries: Array<LlmsFullFixture> = [
+			{ slug: 'stylesheet', shape: 'asset', tier: 'n/a', md: md('stylesheet') },
+			{ slug: 'button', shape: 'component', tier: 'composed', md: md('button') },
 			// component with tier 'n/a' should not slip through as composed.
 			{ md: md('mystery'), shape: 'component', slug: 'mystery', tier: 'n/a' },
 		];
@@ -56,16 +60,16 @@ describe('sortLlmsFullEntries', () => {
 	});
 
 	it('treats atoms before composed regardless of slug ordering', () => {
-		const entries: Array<LlmsFullEntry> = [
-			{ md: md('aardvark'), shape: 'component', slug: 'aardvark', tier: 'composed' },
-			{ md: md('zebra'), shape: 'component', slug: 'zebra', tier: 'atom' },
+		const entries: Array<LlmsFullFixture> = [
+			{ slug: 'aardvark', shape: 'component', tier: 'composed', md: md('aardvark') },
+			{ slug: 'zebra', shape: 'component', tier: 'atom', md: md('zebra') },
 		];
 		const sorted = sortLlmsFullEntries(entries).map((e) => e.slug);
 		expect(sorted).toEqual(['zebra', 'aardvark']);
 	});
 
 	it('places barrels before primitives even when primitive slugs sort earlier', () => {
-		const entries: Array<LlmsFullEntry> = [
+		const entries: Array<LlmsFullFixture> = [
 			{
 				md: md('aardvark-primitive'),
 				shape: 'component',
@@ -79,9 +83,9 @@ describe('sortLlmsFullEntries', () => {
 	});
 
 	it('does not mutate the input array', () => {
-		const entries: Array<LlmsFullEntry> = [
-			{ md: md('b'), shape: 'component', slug: 'b', tier: 'composed' },
-			{ md: md('a'), shape: 'component', slug: 'a', tier: 'composed' },
+		const entries: Array<LlmsFullFixture> = [
+			{ slug: 'b', shape: 'component', tier: 'composed', md: md('b') },
+			{ slug: 'a', shape: 'component', tier: 'composed', md: md('a') },
 		];
 		const snapshot = entries.map((e) => e.slug);
 		sortLlmsFullEntries(entries);
@@ -92,7 +96,7 @@ describe('sortLlmsFullEntries', () => {
 describe('renderLlmsFull', () => {
 	it('concatenates markdown in canonical (atom → composed → barrel → primitive) order', () => {
 		// Insertion order is intentionally jumbled.
-		const entries: Array<LlmsFullEntry> = [
+		const entries: Array<LlmsFullFixture> = [
 			{
 				md: md('combobox-field-primitive'),
 				shape: 'component',

--- a/packages/@luke-ui/docs-tools/src/__tests__/render-page.test.ts
+++ b/packages/@luke-ui/docs-tools/src/__tests__/render-page.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { PackageDocsBarrelEntry, PackageDocsComponentEntry } from '../package-docs-catalog.js';
 import type { ParsedComponent } from '../parse-types.js';
 import { renderPage } from '../render-page.js';
 
@@ -20,189 +21,154 @@ const sampleParsed: ParsedComponent = {
 	tier: 'composed',
 };
 
-describe('renderPage component body', () => {
-	it('emits H1 from the export slug, titlecased', () => {
-		const page = renderPage({
-			importPath: '@luke-ui/react/button',
-			kind: 'component',
-			parsed: sampleParsed,
-			proseMarkdown: '<authored usage>',
-			slug: 'button',
-			tier: 'composed',
-		});
-		expect(page).toMatch(/^# Button\n/);
-	});
+function componentEntry(
+	overrides: Partial<PackageDocsComponentEntry> = {},
+): PackageDocsComponentEntry {
+	return {
+		path: './button',
+		target: './dist/button/index.js',
+		slug: 'button',
+		shape: 'component',
+		pageKind: 'component',
+		tier: 'composed',
+		title: 'Button',
+		description: 'Sample composed button.',
+		sourcePath: '/src/button/index.tsx',
+		parsed: sampleParsed,
+		...overrides,
+	};
+}
 
-	it('inserts the description as a blockquote', () => {
-		const page = renderPage({
-			importPath: '@luke-ui/react/button',
-			kind: 'component',
-			parsed: sampleParsed,
-			proseMarkdown: '<authored usage>',
-			slug: 'button',
-			tier: 'composed',
+function renderComponent(
+	entryOverrides: Partial<PackageDocsComponentEntry> = {},
+	proseMarkdown = '',
+): string {
+	return renderPage({
+		entry: componentEntry(entryOverrides),
+		importPath: '@luke-ui/react/button',
+		proseMarkdown,
+	});
+}
+
+const sampleExports = [
+	{
+		name: 'WidgetControl',
+		description: 'The main control.',
+		type: 'function WidgetControl(props: WidgetControlProps): JSX.Element',
+	},
+	{ name: 'WidgetItem', description: 'A single item.', type: undefined },
+];
+
+function barrelEntry(overrides: Partial<PackageDocsBarrelEntry> = {}): PackageDocsBarrelEntry {
+	return {
+		path: './combobox-field/primitive',
+		target: './dist/combobox-field/primitive/index.js',
+		slug: 'combobox-field-primitive',
+		shape: 'component',
+		pageKind: 'barrel',
+		tier: 'primitive',
+		title: 'Combobox Field (primitive)',
+		description: '',
+		sourcePath: '/src/combobox-field/primitive/index.tsx',
+		parsed: { description: '', exports: sampleExports },
+		...overrides,
+	};
+}
+
+function renderBarrel(entryOverrides: Partial<PackageDocsBarrelEntry> = {}): string {
+	return renderPage({
+		entry: barrelEntry(entryOverrides),
+		importPath: '@luke-ui/react/combobox-field/primitive',
+		proseMarkdown: undefined,
+	});
+}
+
+describe('renderPage component body', () => {
+	it('uses resolved catalog metadata for the header', () => {
+		const page = renderComponent({
+			title: 'Resolved Button',
+			description: 'Resolved description.',
 		});
-		expect(page).toContain('> Sample composed button.');
+		expect(page).toMatch(/^# Resolved Button\n/);
+		expect(page).toContain('> Resolved description.');
 	});
 
 	it('renders the import block', () => {
-		const page = renderPage({
-			importPath: '@luke-ui/react/button',
-			kind: 'component',
-			parsed: sampleParsed,
-			proseMarkdown: '',
-			slug: 'button',
-			tier: 'composed',
-		});
-		expect(page).toContain("import { Button } from '@luke-ui/react/button';");
+		expect(renderComponent()).toContain("import { Button } from '@luke-ui/react/button';");
 	});
 
 	it('uses parsed.componentName for the import identifier when the export is renamed', () => {
 		const page = renderPage({
+			entry: componentEntry({
+				path: './text-field/primitive',
+				slug: 'text-field-primitive',
+				tier: 'primitive',
+				title: 'Text Field (primitive)',
+				parsed: { ...sampleParsed, componentName: 'TextInput' },
+			}),
 			importPath: '@luke-ui/react/text-field/primitive',
-			kind: 'component',
-			parsed: { ...sampleParsed, componentName: 'TextInput' },
 			proseMarkdown: undefined,
-			slug: 'text-field-primitive',
-			tier: 'primitive',
 		});
 		expect(page).toContain("import { TextInput } from '@luke-ui/react/text-field/primitive';");
 	});
 
 	it('renders the props table with own props only', () => {
-		const page = renderPage({
-			importPath: '@luke-ui/react/button',
-			kind: 'component',
-			parsed: sampleParsed,
-			proseMarkdown: '',
-			slug: 'button',
-			tier: 'composed',
-		});
-		expect(page).toMatch(
+		expect(renderComponent()).toMatch(
 			/\| `size` \| `'small' \\\| 'medium'` \| `'medium'` \| Sets the size\. \|/,
 		);
 	});
 
 	it('emits an extends pointer for external types', () => {
-		const page = renderPage({
-			importPath: '@luke-ui/react/button',
-			kind: 'component',
-			parsed: sampleParsed,
-			proseMarkdown: '',
-			slug: 'button',
-			tier: 'composed',
-		});
-		expect(page).toContain('Extends [`react-aria-components` `ButtonProps`]');
+		expect(renderComponent()).toContain('Extends [`react-aria-components` `ButtonProps`]');
 	});
 
 	it('omits Usage section for primitives', () => {
-		const page = renderPage({
-			importPath: '@luke-ui/react/button/primitive',
-			kind: 'component',
-			parsed: sampleParsed,
-			proseMarkdown: undefined,
-			slug: 'button-primitive',
-			tier: 'primitive',
-		});
-		expect(page).not.toContain('## Usage');
-	});
-
-	it('renders a (primitive) suffix on the title for primitive tier', () => {
-		const page = renderPage({
-			importPath: '@luke-ui/react/button/primitive',
-			kind: 'component',
-			parsed: sampleParsed,
-			proseMarkdown: undefined,
-			slug: 'button-primitive',
-			tier: 'primitive',
-		});
-		expect(page).toMatch(/^# Button \(primitive\)\n/);
+		expect(
+			renderComponent({ tier: 'primitive', title: 'Button (primitive)' }, '<authored usage>'),
+		).not.toContain('## Usage');
 	});
 });
 
 describe('renderPage barrel body', () => {
-	const sampleExports = [
-		{
-			description: 'The main control.',
-			name: 'WidgetControl',
-			type: 'function WidgetControl(props: WidgetControlProps): JSX.Element',
-		},
-		{ description: 'A single item.', name: 'WidgetItem', type: undefined },
-	];
-
-	it('emits an H1 with the slug title', () => {
-		const page = renderPage({
-			exports: sampleExports,
-			importPath: '@luke-ui/react/combobox-field/primitive',
-			kind: 'barrel',
-			slug: 'combobox-field-primitive',
-			tier: 'primitive',
-		});
-		expect(page).toMatch(/^# Combobox Field \(primitive\)\n/);
+	it('uses the resolved title', () => {
+		expect(renderBarrel()).toMatch(/^# Combobox Field \(primitive\)\n/);
 	});
 
 	it('renders an Import block listing all exports', () => {
-		const page = renderPage({
-			exports: sampleExports,
-			importPath: '@luke-ui/react/combobox-field/primitive',
-			kind: 'barrel',
-			slug: 'combobox-field-primitive',
-			tier: 'primitive',
-		});
-		expect(page).toContain(
+		expect(renderBarrel()).toContain(
 			"import { WidgetControl, WidgetItem } from '@luke-ui/react/combobox-field/primitive';",
 		);
 	});
 
 	it('marks type-only exports in the import block', () => {
-		const page = renderPage({
-			exports: [
-				{ description: 'Allowed levels.', name: 'HeadingLevel', type: 'type HeadingLevel = 1' },
-				{ description: 'Provider.', name: 'HeadingLevels', type: undefined },
-			],
-			importPath: '@luke-ui/react/heading-context',
-			kind: 'barrel',
-			slug: 'heading-context',
-			tier: 'n/a',
+		const page = renderBarrel({
+			parsed: {
+				description: '',
+				exports: [
+					{
+						name: 'HeadingLevel',
+						description: 'Allowed levels.',
+						type: 'type HeadingLevel = 1',
+					},
+					{ name: 'HeadingLevels', description: 'Provider.', type: undefined },
+				],
+			},
 		});
-		expect(page).toContain(
-			"import { type HeadingLevel, HeadingLevels } from '@luke-ui/react/heading-context';",
-		);
+		expect(page).toContain('import { type HeadingLevel, HeadingLevels }');
 	});
 
-	it('renders an ## Exports section with each export as an H3', () => {
-		const page = renderPage({
-			exports: sampleExports,
-			importPath: '@luke-ui/react/combobox-field/primitive',
-			kind: 'barrel',
-			slug: 'combobox-field-primitive',
-			tier: 'primitive',
-		});
+	it('renders each export with descriptions and type signatures', () => {
+		const page = renderBarrel();
 		expect(page).toContain('## Exports');
 		expect(page).toContain('### `WidgetControl`');
 		expect(page).toContain('### `WidgetItem`');
-	});
-
-	it('renders description as blockquote when provided', () => {
-		const page = renderPage({
-			description: 'A barrel of field primitives.',
-			exports: sampleExports,
-			importPath: '@luke-ui/react/field/primitive',
-			kind: 'barrel',
-			slug: 'field-primitive',
-			tier: 'primitive',
-		});
-		expect(page).toContain('> A barrel of field primitives.');
-	});
-
-	it('renders type signature in a code fence when present', () => {
-		const page = renderPage({
-			exports: sampleExports,
-			importPath: '@luke-ui/react/combobox-field/primitive',
-			kind: 'barrel',
-			slug: 'combobox-field-primitive',
-			tier: 'primitive',
-		});
+		expect(page).toContain('The main control.');
 		expect(page).toContain('function WidgetControl(props: WidgetControlProps): JSX.Element');
+	});
+
+	it('renders the resolved description as a blockquote', () => {
+		expect(renderBarrel({ description: 'A barrel of field primitives.' })).toContain(
+			'> A barrel of field primitives.',
+		);
 	});
 });

--- a/packages/@luke-ui/docs-tools/src/package-docs-catalog.ts
+++ b/packages/@luke-ui/docs-tools/src/package-docs-catalog.ts
@@ -1,0 +1,110 @@
+import { existsSync } from 'node:fs';
+import type {
+	DiscoveredExport,
+	ExportPageKind,
+	ExportShape,
+	ExportTier,
+} from '@luke-ui/docs-tools/discover-exports';
+import { discoverExports } from '@luke-ui/docs-tools/discover-exports';
+import type { ParsedBarrel, ParsedComponent } from '@luke-ui/docs-tools/parse-types';
+import { parseBarrel, parseComponent } from '@luke-ui/docs-tools/parse-types';
+import { slugToTitle } from '@luke-ui/docs-tools/title';
+
+interface PackageDocsCatalogEntryBase {
+	path: string;
+	target: string;
+	slug: string;
+	shape: ExportShape;
+	pageKind: ExportPageKind;
+	tier: ExportTier;
+	title: string;
+	description: string;
+}
+
+export interface PackageDocsAssetEntry extends PackageDocsCatalogEntryBase {
+	shape: 'asset';
+	pageKind: 'asset';
+	tier: 'n/a';
+}
+
+export interface PackageDocsComponentEntry extends PackageDocsCatalogEntryBase {
+	pageKind: 'component';
+	sourcePath: string;
+	parsed: ParsedComponent;
+}
+
+export interface PackageDocsBarrelEntry extends PackageDocsCatalogEntryBase {
+	pageKind: 'barrel';
+	sourcePath: string;
+	parsed: ParsedBarrel;
+}
+
+export type PackageDocsCatalogEntry =
+	| PackageDocsAssetEntry
+	| PackageDocsComponentEntry
+	| PackageDocsBarrelEntry;
+
+export type PackageDocsCatalogMetadata = Pick<
+	PackageDocsCatalogEntry,
+	'path' | 'target' | 'slug' | 'shape' | 'pageKind' | 'tier' | 'title' | 'description'
+>;
+
+export interface ResolvePackageDocsCatalogOptions {
+	exportsField: Record<string, string>;
+	packageRoot: string;
+}
+
+export function resolvePackageDocsCatalog(
+	options: ResolvePackageDocsCatalogOptions,
+): Array<PackageDocsCatalogEntry> {
+	const discovered = discoverExports(options.exportsField, {
+		packageRoot: options.packageRoot,
+	});
+
+	return discovered.map(resolveEntry);
+}
+
+function resolveEntry(entry: DiscoveredExport): PackageDocsCatalogEntry {
+	if (entry.pageKind === 'asset') {
+		return {
+			path: entry.path,
+			target: entry.target,
+			slug: entry.slug,
+			shape: 'asset',
+			pageKind: 'asset',
+			tier: 'n/a',
+			title: slugToTitle(entry.slug, entry.tier),
+			description: '',
+		};
+	}
+
+	if (!entry.sourcePath || !existsSync(entry.sourcePath)) {
+		throw new Error(
+			`Could not resolve source for package export "${entry.path}" targeting "${entry.target}".`,
+		);
+	}
+
+	if (entry.pageKind === 'barrel') {
+		const parsed = parseBarrel(entry.sourcePath);
+		return {
+			...entry,
+			pageKind: 'barrel',
+			sourcePath: entry.sourcePath,
+			title: slugToTitle(entry.slug, entry.tier),
+			description: parsed.description,
+			parsed,
+		};
+	}
+
+	const parsed = parseComponent(entry.sourcePath);
+	const tier = parsed.tier ?? entry.tier;
+	return {
+		...entry,
+		pageKind: 'component',
+		sourcePath: entry.sourcePath,
+		tier,
+		title: slugToTitle(entry.slug, tier),
+		description: parsed.description,
+		parsed,
+	};
+}

--- a/packages/@luke-ui/docs-tools/src/render-index.ts
+++ b/packages/@luke-ui/docs-tools/src/render-index.ts
@@ -1,8 +1,6 @@
-import type { DiscoveredExport } from './discover-exports.js';
-import { slugToTitle } from './title.js';
+import type { PackageDocsCatalogMetadata } from './package-docs-catalog.js';
 
-export interface IndexEntry extends DiscoveredExport {
-	description?: string;
+export interface IndexEntry extends PackageDocsCatalogMetadata {
 	href?: string;
 }
 
@@ -85,7 +83,6 @@ export function renderIndex(input: RenderIndexInput): string {
 
 function formatLink(e: IndexEntry): string {
 	const desc = e.description ? `: ${e.description}` : '';
-	const title = slugToTitle(e.slug, e.tier);
 	const href = e.href ?? `./${e.slug}.md`;
-	return `- [${title}](${href})${desc}`;
+	return `- [${e.title}](${href})${desc}`;
 }

--- a/packages/@luke-ui/docs-tools/src/render-llms-full.ts
+++ b/packages/@luke-ui/docs-tools/src/render-llms-full.ts
@@ -1,12 +1,7 @@
-import type { ExportShape, ExportTier } from './discover-exports.js';
+import type { PackageDocsCatalogMetadata } from './package-docs-catalog.js';
 
-export interface LlmsFullEntry {
+export interface LlmsFullEntry extends Pick<PackageDocsCatalogMetadata, 'slug' | 'shape' | 'tier'> {
 	md: string;
-	shape: ExportShape;
-	/** The slug used for the generated .md filename, e.g. 'button' or 'button-primitive'. */
-	slug: string;
-	/** Effective tier for the entry, including any JSDoc `@tier` overrides. */
-	tier: ExportTier;
 }
 
 /**

--- a/packages/@luke-ui/docs-tools/src/render-page.ts
+++ b/packages/@luke-ui/docs-tools/src/render-page.ts
@@ -1,48 +1,30 @@
-import type { ExportTier } from './discover-exports.js';
-import type { ParsedBarrelExport, ParsedComponent } from './parse-types.js';
-import { slugToTitle } from './title.js';
+import type { PackageDocsBarrelEntry, PackageDocsComponentEntry } from './package-docs-catalog.js';
 
 const RAC_DOCS_BASE = 'https://react-spectrum.adobe.com/react-aria';
 
-interface RenderComponentPageInput {
+interface RenderPageInput {
+	entry: PackageDocsComponentEntry | PackageDocsBarrelEntry;
 	importPath: string;
-	kind: 'component';
-	parsed: ParsedComponent;
 	/** Authored Markdown prose for the Usage section. Undefined for primitives. */
 	proseMarkdown: string | undefined;
-	slug: string;
-	tier: ExportTier;
 }
-
-interface RenderBarrelPageInput {
-	description?: string;
-	exports: Array<ParsedBarrelExport>;
-	importPath: string;
-	kind: 'barrel';
-	slug: string;
-	tier: ExportTier;
-}
-
-export type RenderPageInput = RenderComponentPageInput | RenderBarrelPageInput;
-
 export function renderPage(input: RenderPageInput): string {
 	const lines = renderHeader(input);
-	if (input.kind === 'component') {
-		renderComponentBody(lines, input);
+	if (input.entry.pageKind === 'component') {
+		renderComponentBody(lines, input.entry, input.proseMarkdown);
 	} else {
-		renderBarrelBody(lines, input);
+		renderBarrelBody(lines, input.entry);
 	}
 	return lines.join('\n');
 }
 
 function renderHeader(input: RenderPageInput): Array<string> {
 	const lines: Array<string> = [];
-	const description = input.kind === 'component' ? input.parsed.description : input.description;
 
-	lines.push(`# ${slugToTitle(input.slug, input.tier)}`);
+	lines.push(`# ${input.entry.title}`);
 	lines.push('');
-	if (description) {
-		lines.push(`> ${description.replace(/\n/g, ' ')}`);
+	if (input.entry.description) {
+		lines.push(`> ${input.entry.description.replace(/\n/g, ' ')}`);
 		lines.push('');
 	}
 
@@ -57,19 +39,23 @@ function renderHeader(input: RenderPageInput): Array<string> {
 }
 
 function importStatement(input: RenderPageInput): string {
-	if (input.kind === 'barrel') {
-		const importNames = input.exports.map((e) =>
+	if (input.entry.pageKind === 'barrel') {
+		const importNames = input.entry.parsed.exports.map((e) =>
 			e.type?.startsWith('type ') ? `type ${e.name}` : e.name,
 		);
 		return `import { ${importNames.join(', ')} } from '${input.importPath}';`;
 	}
 
-	const importIdent = input.parsed.componentName ?? exportIdentifier(input.slug);
+	const importIdent = input.entry.parsed.componentName ?? exportIdentifier(input.entry.slug);
 	return `import { ${importIdent} } from '${input.importPath}';`;
 }
 
-function renderComponentBody(lines: Array<string>, input: RenderComponentPageInput): void {
-	const { tier, parsed, proseMarkdown } = input;
+function renderComponentBody(
+	lines: Array<string>,
+	entry: PackageDocsComponentEntry,
+	proseMarkdown: string | undefined,
+): void {
+	const { tier, parsed } = entry;
 
 	if (tier !== 'primitive' && proseMarkdown) {
 		lines.push('## Usage');
@@ -102,11 +88,11 @@ function renderComponentBody(lines: Array<string>, input: RenderComponentPageInp
 	}
 }
 
-function renderBarrelBody(lines: Array<string>, input: RenderBarrelPageInput): void {
+function renderBarrelBody(lines: Array<string>, entry: PackageDocsBarrelEntry): void {
 	lines.push('## Exports');
 	lines.push('');
 
-	for (const e of input.exports) {
+	for (const e of entry.parsed.exports) {
 		lines.push(`### \`${e.name}\``);
 		lines.push('');
 		if (e.type) {

--- a/packages/@luke-ui/react/scripts/generate-docs.ts
+++ b/packages/@luke-ui/react/scripts/generate-docs.ts
@@ -1,8 +1,6 @@
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { discoverExports } from '@luke-ui/docs-tools/discover-exports';
-import { parseBarrel, parseComponent } from '@luke-ui/docs-tools/parse-types';
-import type { IndexEntry } from '@luke-ui/docs-tools/render-index';
+import { resolvePackageDocsCatalog } from '@luke-ui/docs-tools/package-docs-catalog';
 import { renderIndex } from '@luke-ui/docs-tools/render-index';
 import { renderLlmsFull } from '@luke-ui/docs-tools/render-llms-full';
 import { renderPage } from '@luke-ui/docs-tools/render-page';
@@ -12,45 +10,27 @@ import packageJson from '../package.json' with { type: 'json' };
 const packageRoot = fileURLToPath(new URL('../', import.meta.url));
 const docsDir = join(packageRoot, 'docs');
 
-const discovered = discoverExports(packageJson.exports, { packageRoot });
-const descriptionByPath = new Map<string, string>();
-const tierByPath = new Map<string, (typeof discovered)[number]['tier']>();
+const catalog = resolvePackageDocsCatalog({
+	packageRoot,
+	exportsField: packageJson.exports,
+});
 
 await mkdir(docsDir, { recursive: true });
 
 const pages = await Promise.all(
-	discovered.map(async (entry) => {
+	catalog.map(async (entry) => {
 		if (entry.pageKind === 'asset') return;
-		if (!entry.sourcePath) return;
 
-		if (entry.pageKind === 'barrel') {
-			const parsed = parseBarrel(entry.sourcePath);
-			if (parsed.description) descriptionByPath.set(entry.path, parsed.description);
-			const md = renderPage({
-				description: parsed.description,
-				exports: parsed.exports,
-				importPath: `${packageJson.name}${entry.path.replace(/^\./, '')}`,
-				kind: 'barrel',
-				slug: entry.slug,
-				tier: entry.tier,
-			});
-			return { md, shape: entry.shape, slug: entry.slug, tier: entry.tier };
-		}
-
-		const parsed = parseComponent(entry.sourcePath);
-		if (parsed.description) descriptionByPath.set(entry.path, parsed.description);
-		const tier = parsed.tier ?? entry.tier;
-		if (parsed.tier) tierByPath.set(entry.path, parsed.tier);
-		const proseMarkdown = await readProse(packageRoot, entry).catch(() => undefined);
+		const proseMarkdown =
+			entry.pageKind === 'component'
+				? await readProse(packageRoot, entry).catch(() => undefined)
+				: undefined;
 		const md = renderPage({
+			entry,
 			importPath: `${packageJson.name}${entry.path.replace(/^\./, '')}`,
-			kind: 'component',
-			parsed,
 			proseMarkdown,
-			slug: entry.slug,
-			tier,
 		});
-		return { md, shape: entry.shape, slug: entry.slug, tier };
+		return { slug: entry.slug, shape: entry.shape, tier: entry.tier, md };
 	}),
 );
 
@@ -60,17 +40,10 @@ await Promise.all(
 	),
 );
 
-const entriesWithDescriptions: Array<IndexEntry> = discovered.map((entry) => {
-	return Object.assign({}, entry, {
-		description: descriptionByPath.get(entry.path),
-		tier: tierByPath.get(entry.path) ?? entry.tier,
-	});
-});
-
 const llmsTxt = renderIndex({
-	entries: entriesWithDescriptions,
-	includeLibraryAuthors: true,
 	packageName: packageJson.name,
+	entries: catalog,
+	includeLibraryAuthors: true,
 });
 
 await writeFile(join(docsDir, 'llms.txt'), llmsTxt, 'utf8');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/@luke-ui/docs-tools:
     dependencies:


### PR DESCRIPTION
Moves package docs metadata resolution into a single 'catalog' module that owns export classification, tier, title, description, and parsed data. Renderers consume this catalog instead of re-parsing and re-classifying exports.

Closes architecture review candidate: Resolve Package Docs Through One Catalog.