### PR TITLE
refactor: propagate combobox size from primitive root

### DIFF
--- a/packages/@luke-ui/react/src/combobox-field/combobox-field.docs.md
+++ b/packages/@luke-ui/react/src/combobox-field/combobox-field.docs.md
@@ -105,3 +105,10 @@ import {
 	ComboboxSection,
 } from '@luke-ui/react/combobox-field/primitive';
 ```
+
+### Size propagation
+
+When you set `size` on `ComboboxInput`, it is automatically inherited by
+`ComboboxControl`, `ComboboxTextInput`, `ComboboxTrigger`, `ComboboxItem`, and
+`ComboboxLoadMoreItem`. You can override the inherited size on any individual
+child by passing an explicit `size` prop to that component.

--- a/packages/@luke-ui/react/src/combobox-field/combobox-field.stories.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/combobox-field.stories.tsx
@@ -126,25 +126,69 @@ export const Controlled = meta.story({
 	},
 });
 
+const sizeStoryItems: Array<CountryItem> = [...countryItems, { id: 'override', label: 'Override' }];
+
 /**
  * The input supports two sizes: small and medium (default).
  * Prefer using size consistently with other form controls.
  */
 export const Size = meta.story({
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const page = within(document.body);
+
+		const smallInput = canvas.getByRole('combobox', { name: 'Small' });
+		const mediumInput = canvas.getByRole('combobox', { name: 'Medium (default)' });
+		const smallControl = smallInput.closest('[role="group"]')!;
+		const mediumControl = mediumInput.closest('[role="group"]')!;
+
+		// Verify controls have different computed block sizes
+		await expect(window.getComputedStyle(smallControl).minHeight).not.toBe(
+			window.getComputedStyle(mediumControl).minHeight,
+		);
+
+		// Open small combobox and check first option padding
+		await userEvent.click(smallInput);
+		const smallOptions = page.getAllByRole('option');
+		await expect(smallOptions.length).toBeGreaterThan(0);
+		const smallFirstOption = smallOptions[0]!;
+		const smallOptionPadding = window.getComputedStyle(smallFirstOption).paddingBlock;
+
+		// Close small and open medium
+		await userEvent.keyboard('{Escape}');
+		await userEvent.click(mediumInput);
+		const mediumOptions = page.getAllByRole('option');
+		await expect(mediumOptions.length).toBeGreaterThan(0);
+		const mediumFirstOption = mediumOptions[0]!;
+		const mediumOptionPadding = window.getComputedStyle(mediumFirstOption).paddingBlock;
+
+		await expect(smallOptionPadding).not.toBe(mediumOptionPadding);
+
+		// Close medium and open small again to check override
+		await userEvent.keyboard('{Escape}');
+		await userEvent.click(smallInput);
+		const overrideOption = page.getByRole('option', { name: 'Override' });
+		const overridePadding = window.getComputedStyle(overrideOption).paddingBlock;
+		await expect(overridePadding).toBe(mediumOptionPadding);
+	},
 	render: function Render() {
 		return (
 			<div style={stackStyle}>
 				<ComboboxField
-					defaultItems={countryItems}
+					defaultItems={sizeStoryItems}
 					label="Small"
 					name="small"
 					placeholder="Small"
 					size="small"
 				>
-					{(item) => <ComboboxItem size="small">{item.label}</ComboboxItem>}
+					{(item) => (
+						<ComboboxItem size={item.id === 'override' ? 'medium' : undefined}>
+							{item.label}
+						</ComboboxItem>
+					)}
 				</ComboboxField>
 				<ComboboxField
-					defaultItems={countryItems}
+					defaultItems={sizeStoryItems}
 					label="Medium (default)"
 					name="medium"
 					placeholder="Medium"

--- a/packages/@luke-ui/react/src/combobox-field/index.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/index.tsx
@@ -99,16 +99,16 @@ export function ComboboxField<T extends object>(props: ComboboxFieldProps<T>): J
 	const isAsync = loadingState != null;
 
 	return (
-		<ComboboxInput<T> {...comboboxInputProps}>
+		<ComboboxInput<T> size={size} {...comboboxInputProps}>
 			<Field
 				description={description}
 				errorMessage={errorMessage}
 				label={label}
 				necessityIndicator={necessityIndicator}
 			>
-				<ComboboxControl size={size}>
-					<ComboboxTextInput placeholder={placeholder} size={size} />
-					<ComboboxTrigger aria-label="Toggle options" size={size}>
+				<ComboboxControl>
+					<ComboboxTextInput placeholder={placeholder} />
+					<ComboboxTrigger aria-label="Toggle options">
 						<Icon aria-hidden name="chevronDown" size={size === 'small' ? 'xsmall' : 'small'} />
 					</ComboboxTrigger>
 				</ComboboxControl>

--- a/packages/@luke-ui/react/src/combobox-field/primitive/control.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/control.tsx
@@ -5,6 +5,7 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../../recipes/combobox.css.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import { useComboboxSize } from './size-context.js';
 
 interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
 
@@ -25,7 +26,8 @@ export interface ComboboxControlProps
 
 /** Control wrapper for combobox text input + trigger content. */
 export function ComboboxControl(props: ComboboxControlProps): JSX.Element {
-	const { size = 'medium', ...groupProps } = props;
+	const { size: sizeProp, ...groupProps } = props;
+	const size = useComboboxSize(sizeProp);
 
 	return (
 		<RacGroup

--- a/packages/@luke-ui/react/src/combobox-field/primitive/input.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/input.tsx
@@ -6,6 +6,7 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../../recipes/combobox.css.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import { useComboboxSize } from './size-context.js';
 
 interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
 
@@ -27,7 +28,8 @@ export interface ComboboxTextInputProps
 
 /** Text input used within `ComboboxControl` for combobox behavior. */
 export function ComboboxTextInput(props: ComboboxTextInputProps): JSX.Element {
-	const { onClick, size = 'medium', ...inputProps } = props;
+	const { onClick, size: sizeProp, ...inputProps } = props;
+	const size = useComboboxSize(sizeProp);
 	const state = useContext(ComboBoxStateContext);
 
 	const handleClick = (event: React.MouseEvent<HTMLInputElement>) => {

--- a/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
@@ -11,6 +11,7 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../../recipes/combobox.css.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import { useComboboxSize } from './size-context.js';
 
 interface ComboboxStyleProps {
 	size?: 'small' | 'medium';
@@ -27,7 +28,8 @@ export interface ComboboxItemProps<T extends object>
 }
 
 export function ComboboxItem<T extends object>(props: ComboboxItemProps<T>): JSX.Element {
-	const { size = 'medium', ...itemProps } = props;
+	const { size: sizeProp, ...itemProps } = props;
+	const size = useComboboxSize(sizeProp);
 
 	return (
 		<RacListBoxItem
@@ -50,7 +52,8 @@ export interface ComboboxLoadMoreItemProps
 }
 
 export function ComboboxLoadMoreItem(props: ComboboxLoadMoreItemProps): JSX.Element {
-	const { size = 'medium', ...loadMoreItemProps } = props;
+	const { size: sizeProp, ...loadMoreItemProps } = props;
+	const size = useComboboxSize(sizeProp);
 
 	return (
 		<RacListBoxLoadMoreItem

--- a/packages/@luke-ui/react/src/combobox-field/primitive/root.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/root.tsx
@@ -5,6 +5,7 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../../recipes/combobox.css.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import { ComboboxSizeProvider } from './size-context.js';
 
 interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
 
@@ -40,20 +41,25 @@ export interface ComboboxInputProps<T extends object> extends DistributiveOmit<
 
 	/** Called when the open state changes. */
 	onOpenChange?: (isOpen: boolean) => void;
+
+	/** Control size. @default 'medium' */
+	size?: ComboboxSize;
 	/** The currently selected key (controlled). Pass `null` for no selection. */
 	value?: Key | null;
 }
 
 export function ComboboxInput<T extends object>(props: ComboboxInputProps<T>): JSX.Element {
-	const { className, menuTrigger = 'focus', ...comboboxProps } = props;
+	const { className, menuTrigger = 'focus', size = 'medium', ...comboboxProps } = props;
 
 	return (
-		<RacComboBox
-			{...comboboxProps}
-			className={composeRenderProps(className, (renderedClassName) => {
-				return cx(styles.comboboxRoot, renderedClassName);
-			})}
-			menuTrigger={menuTrigger}
-		/>
+		<ComboboxSizeProvider size={size}>
+			<RacComboBox
+				{...comboboxProps}
+				className={composeRenderProps(className, (renderedClassName) => {
+					return cx(styles.comboboxRoot, renderedClassName);
+				})}
+				menuTrigger={menuTrigger}
+			/>
+		</ComboboxSizeProvider>
 	);
 }

--- a/packages/@luke-ui/react/src/combobox-field/primitive/size-context.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/size-context.tsx
@@ -1,0 +1,19 @@
+import type { JSX, ReactNode } from 'react';
+import { createContext, use } from 'react';
+import type { ComboboxSize } from './root.js';
+
+const ComboboxSizeContext = createContext<ComboboxSize | null>(null);
+
+export function useComboboxSize(size?: ComboboxSize): ComboboxSize {
+	return size ?? use(ComboboxSizeContext) ?? 'medium';
+}
+
+export function ComboboxSizeProvider({
+	size,
+	children,
+}: {
+	size: ComboboxSize;
+	children: ReactNode;
+}): JSX.Element {
+	return <ComboboxSizeContext.Provider value={size}>{children}</ComboboxSizeContext.Provider>;
+}

--- a/packages/@luke-ui/react/src/combobox-field/primitive/trigger.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/trigger.tsx
@@ -5,6 +5,7 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../../recipes/combobox.css.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import { useComboboxSize } from './size-context.js';
 
 interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
 
@@ -24,7 +25,8 @@ export interface ComboboxTriggerProps
 
 /** Trigger button used by combobox pattern. */
 export function ComboboxTrigger(props: ComboboxTriggerProps): JSX.Element {
-	const { size = 'medium', ...buttonProps } = props;
+	const { size: sizeProp, ...buttonProps } = props;
+	const size = useComboboxSize(sizeProp);
 
 	return (
 		<RacButton


### PR DESCRIPTION
Adds a private 'ComboboxSizeContext' so the primitive root owns size propagation. Control, TextInput, Trigger, Item, and LoadMoreItem all consume size via context, with explicit child props overriding the inherited value.

The composed 'ComboboxField' now passes 'size' only to the root primitive instead of forwarding it to every child.

Closes architecture review candidate: Make the Combobox Primitive Own Size.