### PR TITLE
Deepen component creation generator

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,8 @@ A building block whose audience is library authors assembling the next composed 
 _Examples_: `TextInput` (via `text-field/primitive`), the `Combobox*` kit (via `combobox-field/primitive`), `button/primitive`, `field/primitive`, the composed-but-internal `Field`.
 _Avoid_: "base", "raw" — use **Primitive**.
 
+**Component creation**: the act of adding a new Atom or Composed component and every public surface needed for it to exist consistently. It includes source, stories, package docs, hosted docs, recipes when needed, and export refresh.
+
 ## Relationships
 
 - A **Composed** component is built from one or more **Atoms** and/or **Primitives**.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -36,4 +36,5 @@ The `button/primitive` path follows the same pattern.
 
 ## Exports
 
-Managed by `tsdown`. Do not hand-edit `.generated/entries.ts`; it is generated. `package.json#exports` is updated automatically at build.
+Managed by `tsdown` entry globs. Do not hand-edit `package.json#exports`.
+Create files in paths the package build already discovers.

--- a/docs/adr/0005-component-creation-plan-module.md
+++ b/docs/adr/0005-component-creation-plan-module.md
@@ -1,0 +1,8 @@
+# Component creation uses a plan module
+
+Component creation is modeled as a module whose interface returns a plan for the files and checks needed to add an Atom or Composed component. Turbo/Plop remains an adapter that applies the plan, rather than the place where component creation rules live. This keeps the interface test surface on Luke UI's component creation rules, while the adapter stays thin and replaceable.
+
+## Considered Options
+
+- **Keep all logic in the Turbo generator**: rejected because it makes Plop the test surface and spreads Atom, Composed, docs, story, recipe, and export-placement rules through one shallow script.
+- **Create files directly without a plan**: rejected because it makes dry-run tests and fixture assertions harder, and it hides the exact public surfaces a component creation input should produce.

--- a/packages/@luke-ui/react/package.json
+++ b/packages/@luke-ui/react/package.json
@@ -45,7 +45,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "pnpm run generate && pnpm run build:tsdown",
+		"build": "pnpm run build:tsdown",
 		"build:storybook": "storybook build",
 		"build:tsdown": "vp pack",
 		"check:docs": "pnpm run generate:docs",
@@ -62,7 +62,8 @@
 		"fix:format": "vp fmt . --write",
 		"fix:lint": "vp lint . --type-aware --fix",
 		"fix:unsafe": "vp lint . --type-aware --fix-dangerously",
-		"generate": "pnpm run generate:icons && pnpm run generate:color-tokens && pnpm run generate:docs",
+		"generate": "pnpm run generate:assets",
+		"generate:assets": "pnpm run generate:icons && pnpm run generate:color-tokens",
 		"generate:color-tokens": "node scripts/generate-color-tokens.ts && vp fmt .generated/color-tokens.generated.ts --write",
 		"generate:docs": "tsx scripts/generate-docs.ts && vp fmt docs/ dist/docs/ --write",
 		"generate:icons": "tsx scripts/build-icons.ts",
@@ -110,7 +111,8 @@
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vite-plus": "catalog:",
-		"vitest": "catalog:"
+		"vitest": "catalog:",
+		"zod": "catalog:"
 	},
 	"peerDependencies": {
 		"react": "catalog:",

--- a/packages/@luke-ui/react/src/build/__tests__/package-scripts.test.ts
+++ b/packages/@luke-ui/react/src/build/__tests__/package-scripts.test.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vite-plus/test';
+import { z } from 'zod';
+
+const packageJsonPath = fileURLToPath(new URL('../../../package.json', import.meta.url));
+const turboJsonPath = fileURLToPath(new URL('../../../../../../turbo.json', import.meta.url));
+const packageJsonSchema = z.object({
+	scripts: z.record(z.string(), z.string()),
+});
+const turboJsonSchema = z.object({
+	tasks: z.record(
+		z.string(),
+		z.object({
+			dependsOn: z.array(z.string()).optional(),
+		}),
+	),
+});
+
+describe('package scripts', () => {
+	it('lets Turbo order build before package docs generation', async () => {
+		const packageJson = packageJsonSchema.parse(
+			JSON.parse(await readFile(packageJsonPath, 'utf8')),
+		);
+		const turboJson = turboJsonSchema.parse(JSON.parse(await readFile(turboJsonPath, 'utf8')));
+
+		expect(packageJson.scripts.build).toBe('pnpm run build:tsdown');
+		expect(packageJson.scripts.generate).toBe('pnpm run generate:assets');
+		expect(turboJson.tasks['@luke-ui/react#generate:docs']?.dependsOn).toContain('build');
+		expect(turboJson.tasks['docs#dev']?.dependsOn).toContain('@luke-ui/react#generate:docs');
+	});
+});

--- a/packages/turbo-generators/README.md
+++ b/packages/turbo-generators/README.md
@@ -4,7 +4,13 @@ Custom generators for `turbo generate`.
 
 ## Generators
 
-- `component`: Scaffolds `@luke-ui/react` components (primitives, stories, package docs) and docs app wrappers, updates docs navigation/content links, then runs `build:tsdown` to refresh tsdown-managed exports.
+- `component`: Scaffolds Atom and Composed `@luke-ui/react` components,
+  package docs prose, Storybook stories, hosted docs wrappers, hosted docs
+  controls, and structural docs navigation.
+
+The component generator asks for name, tier, docs group, and styling. Primitive
+creation is intentionally excluded until it can be modeled with a parent
+Composed component.
 
 ## Usage
 
@@ -14,5 +20,6 @@ pnpm generate:component
 
 ## Structure
 
-- `config.ts`: Registration and actions.
-- `templates/`: Handlebars templates.
+- `config.ts`: Turbo/Plop adapter.
+- `src/component-creation-plan.ts`: Component creation rules and expected outcomes.
+- `src/apply-component-creation-plan.ts`: File and JSON edit adapter.

--- a/packages/turbo-generators/config.ts
+++ b/packages/turbo-generators/config.ts
@@ -1,352 +1,99 @@
-import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import type { PlopTypes } from '@turbo/gen';
+import { applyComponentCreationPlan } from './src/apply-component-creation-plan.js';
+import type {
+	ComponentStyling,
+	ComponentTier,
+	CreateComponentInput,
+} from './src/component-creation-plan.js';
+import { createComponentPlan } from './src/component-creation-plan.js';
 
 const DOCS_GROUPS = ['actions', 'feedback', 'forms', 'typography', 'visuals'] as const;
-
 const COMPONENT_NAME_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
-const CAMEL_BOUNDARY_RE = /([a-z0-9])([A-Z])/g;
-const NON_ALPHANUM_RE = /[^A-Za-z0-9-]/g;
-const TRAILING_WHITESPACE_RE = /\s+$/;
-const TRAILING_NEWLINES_RE = /\n*$/;
 
-type GeneratorAnswers = {
-	group?: string;
+interface ComponentAnswers {
+	docsGroup?: string;
 	name?: string;
-};
-
-function validateComponentName(value: unknown): true | string {
-	if (typeof value !== 'string') {
-		return 'Component name is required.';
-	}
-
-	const trimmed = value.trim();
-	if (!trimmed) {
-		return 'Component name is required.';
-	}
-
-	if (!COMPONENT_NAME_RE.test(trimmed)) {
-		return 'Use letters/numbers/hyphens. Start with a letter.';
-	}
-
-	return true;
-}
-
-function toKebabCase(value: string): string {
-	return value
-		.trim()
-		.replaceAll(CAMEL_BOUNDARY_RE, '$1-$2')
-		.replaceAll(NON_ALPHANUM_RE, '-')
-		.toLowerCase();
-}
-
-function toDisplayName(value: string): string {
-	const kebab = toKebabCase(value);
-	let result = '';
-	let capitalize = true;
-
-	for (let i = 0; i < kebab.length; i += 1) {
-		const ch = kebab.charAt(i);
-		if (ch === '-') {
-			result += ' ';
-			capitalize = true;
-		} else {
-			result += capitalize ? ch.toUpperCase() : ch;
-			capitalize = false;
-		}
-	}
-
-	return result;
-}
-
-function toCamelCase(value: string): string {
-	const kebab = toKebabCase(value);
-	let result = '';
-	let capitalize = false;
-
-	for (let i = 0; i < kebab.length; i += 1) {
-		const ch = kebab.charAt(i);
-		if (ch === '-') {
-			capitalize = true;
-		} else {
-			result += capitalize ? ch.toUpperCase() : ch;
-			capitalize = false;
-		}
-	}
-
-	return result;
-}
-
-function resolveGroup(answers: GeneratorAnswers): string {
-	const group = answers.group;
-	if (typeof group !== 'string' || !group.trim()) {
-		throw new Error('Missing required answer: group');
-	}
-	return toKebabCase(group);
-}
-
-function resolveComponentDir(answers: GeneratorAnswers): string {
-	const name = answers.name;
-	if (typeof name !== 'string' || !name.trim()) {
-		throw new Error('Missing required answer: name');
-	}
-
-	return toKebabCase(name);
-}
-
-const DOCS_COMPONENTS_DIR = join(process.cwd(), 'apps/docs/content/docs/components');
-const DOCS_CONTENT_DIR = join(process.cwd(), 'apps/docs/content/docs');
-const DOCS_INDEX_PATH = join(DOCS_CONTENT_DIR, 'index.mdx');
-const GETTING_STARTED_PATH = join(DOCS_CONTENT_DIR, 'getting-started.mdx');
-const RECIPES_LAYERS_PATH = join(
-	process.cwd(),
-	'packages/@luke-ui/react/src/recipes/layers.css.ts',
-);
-const RECIPES_INDEX_PATH = join(process.cwd(), 'packages/@luke-ui/react/src/recipes/index.ts');
-
-function addComponentToDocsMeta(answers: GeneratorAnswers): string {
-	const group = resolveGroup(answers);
-	const componentDir = resolveComponentDir(answers);
-	const groupDir = join(DOCS_COMPONENTS_DIR, group);
-	const groupMetaPath = join(groupDir, 'meta.json');
-
-	mkdirSync(groupDir, { recursive: true });
-
-	let meta: { pages?: Array<string>; title?: string };
-	if (existsSync(groupMetaPath)) {
-		const content = readFileSync(groupMetaPath, 'utf8');
-		meta = JSON.parse(content) as { pages?: Array<string>; title?: string };
-	} else {
-		meta = { pages: [], title: toDisplayName(group) };
-	}
-
-	const pages = Array.isArray(meta.pages) ? meta.pages : [];
-	if (pages.includes(componentDir)) {
-		return `Docs meta already contains ${componentDir}`;
-	}
-
-	pages.push(componentDir);
-	pages.sort();
-	meta.pages = pages;
-	writeFileSync(groupMetaPath, `${JSON.stringify(meta, null, '\t')}\n`);
-
-	const parentMetaPath = join(DOCS_CONTENT_DIR, 'meta.json');
-	const parentContent = readFileSync(parentMetaPath, 'utf8');
-	const parentMeta = JSON.parse(parentContent) as {
-		pages?: Array<string>;
-		title?: string;
-	};
-	const parentPages = Array.isArray(parentMeta.pages) ? parentMeta.pages : [];
-	if (!parentPages.includes(group)) {
-		parentPages.push(group);
-		parentPages.sort();
-		parentMeta.pages = parentPages;
-		writeFileSync(parentMetaPath, `${JSON.stringify(parentMeta, null, '\t')}\n`);
-	}
-
-	return `Added ${componentDir} to docs components ${group} meta`;
-}
-
-function addComponentToDocsIndex(answers: GeneratorAnswers): string {
-	const group = resolveGroup(answers);
-	const componentDir = resolveComponentDir(answers);
-	const href = `/docs/components/${group}/${componentDir}`;
-	const cardLine = `\t<Card title="${toDisplayName(componentDir)} component" href="${href}" />`;
-
-	const content = readFileSync(DOCS_INDEX_PATH, 'utf8');
-	if (content.includes(`href="${href}"`)) {
-		return `Docs index already links ${componentDir}`;
-	}
-
-	const marker = '</Cards>';
-	if (!content.includes(marker)) {
-		throw new Error(`Could not find "${marker}" in ${DOCS_INDEX_PATH}`);
-	}
-
-	const updatedContent = content.replace(marker, `${cardLine}\n${marker}`);
-	writeFileSync(DOCS_INDEX_PATH, updatedContent);
-	return `Added docs index card for ${componentDir}`;
-}
-
-function addComponentToGettingStarted(answers: GeneratorAnswers): string {
-	const group = resolveGroup(answers);
-	const componentDir = resolveComponentDir(answers);
-	const displayName = toDisplayName(componentDir);
-	const nextStepLine = `- Read the [${displayName}](/docs/components/${group}/${componentDir}) docs.`;
-
-	const content = readFileSync(GETTING_STARTED_PATH, 'utf8');
-	if (content.includes(nextStepLine)) {
-		return `Getting Started already links ${componentDir}`;
-	}
-
-	const lines = content.split('\n');
-	let nextStepsIndex = -1;
-	for (let i = 0; i < lines.length; i += 1) {
-		if (lines[i]?.trim() === '## Next Steps') {
-			nextStepsIndex = i;
-			break;
-		}
-	}
-
-	if (nextStepsIndex === -1) {
-		const appended = `${content.replace(TRAILING_WHITESPACE_RE, '')}\n\n## Next Steps\n\n${nextStepLine}\n`;
-		writeFileSync(GETTING_STARTED_PATH, appended);
-		return `Added Next Steps section with ${componentDir}`;
-	}
-
-	let insertAt = lines.length;
-	for (let i = nextStepsIndex + 1; i < lines.length; i += 1) {
-		const line = lines[i];
-		if (line && line.charAt(0) === '#' && line.charAt(1) === '#' && line.charAt(2) === ' ') {
-			insertAt = i;
-			break;
-		}
-	}
-
-	lines.splice(insertAt, 0, nextStepLine);
-	writeFileSync(GETTING_STARTED_PATH, `${lines.join('\n').replace(TRAILING_NEWLINES_RE, '\n')}`);
-	return `Added Getting Started next step for ${componentDir}`;
-}
-
-/** Append new component CSS import to recipes/layers.css.ts and sort. */
-function addComponentToStylesIndex(answers: GeneratorAnswers): string {
-	const componentDir = resolveComponentDir(answers);
-	const newImport = `import './${componentDir}.css.js';`;
-	const content = readFileSync(RECIPES_LAYERS_PATH, 'utf8');
-	if (content.includes(newImport)) {
-		return `Recipes layers already contains ${componentDir} CSS`;
-	}
-
-	const seen = new Set<string>();
-	const imports: Array<string> = [];
-	let start = 0;
-
-	for (let i = 0; i <= content.length; i += 1) {
-		if (i === content.length || content.charAt(i) === '\n') {
-			const line = content.slice(start, i).trim();
-			if (line && !seen.has(line)) {
-				seen.add(line);
-				imports.push(line);
-			}
-			start = i + 1;
-		}
-	}
-
-	if (!seen.has(newImport)) {
-		imports.push(newImport);
-	}
-
-	imports.sort((a, b) => a.localeCompare(b));
-	writeFileSync(RECIPES_LAYERS_PATH, `${imports.join('\n')}\n`);
-	return `Added ${componentDir} CSS to recipes layers`;
-}
-
-function addComponentToRecipesIndex(answers: GeneratorAnswers): string {
-	const componentDir = resolveComponentDir(answers);
-	const pascalName = toDisplayName(componentDir).replaceAll(' ', '');
-	const camelName = toCamelCase(componentDir);
-
-	const typeExport = `export type { ${pascalName}Variants } from './${componentDir}.css.js';`;
-	const valueExport = `export { ${camelName} } from './${componentDir}.css.js';`;
-	const content = readFileSync(RECIPES_INDEX_PATH, 'utf8');
-	if (content.includes(typeExport)) {
-		return `Recipes index already contains ${componentDir}`;
-	}
-
-	let firstExportIndex = -1;
-	for (let i = 0; i < content.length - 6; i += 1) {
-		if (
-			content.charAt(i) === 'e' &&
-			content.charAt(i + 1) === 'x' &&
-			content.charAt(i + 2) === 'p' &&
-			content.charAt(i + 3) === 'o' &&
-			content.charAt(i + 4) === 'r' &&
-			content.charAt(i + 5) === 't' &&
-			content.charAt(i + 6) === ' '
-		) {
-			if (i === 0 || content.charAt(i - 1) === '\n') {
-				firstExportIndex = i;
-				break;
-			}
-		}
-	}
-
-	if (firstExportIndex === -1) {
-		const separator = content.charAt(content.length - 1) === '\n' ? '' : '\n';
-		writeFileSync(RECIPES_INDEX_PATH, `${content}${separator}${typeExport}\n${valueExport}\n`);
-		return `Added ${componentDir} to recipes index`;
-	}
-	const newBlock = `${typeExport}\n${valueExport}\n`;
-	const updated = `${content.slice(0, firstExportIndex)}${newBlock}${content.slice(firstExportIndex)}`;
-	writeFileSync(RECIPES_INDEX_PATH, updated);
-	return `Added ${componentDir} to recipes index`;
-}
-
-function syncTsdownExports(): string {
-	execSync('pnpm --dir packages/@luke-ui/react run build:tsdown', {
-		cwd: process.cwd(),
-		stdio: 'inherit',
-	});
-	return 'Synced tsdown exports and build outputs';
+	styling?: ComponentStyling;
+	tier?: ComponentTier;
 }
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
-	plop.setHelper('displayName', (value: unknown): string => {
-		return typeof value === 'string' ? toDisplayName(value) : '';
-	});
-
 	plop.setGenerator('component', {
 		actions: [
-			{
-				path: '{{ turbo.paths.root }}/packages/@luke-ui/react/src/{{kebabCase name}}/index.tsx',
-				templateFile: 'templates/component/component.tsx.hbs',
-				type: 'add',
-			},
-			{
-				path: '{{ turbo.paths.root }}/packages/@luke-ui/react/src/recipes/{{kebabCase name}}.css.ts',
-				templateFile: 'templates/component/component.recipe.css.ts.hbs',
-				type: 'add',
-			},
-			{
-				path: '{{ turbo.paths.root }}/packages/@luke-ui/react/src/{{kebabCase name}}.stories.tsx',
-				templateFile: 'templates/component/component.stories.tsx.hbs',
-				type: 'add',
-			},
-			{
-				path: '{{ turbo.paths.root }}/packages/@luke-ui/react/src/{{kebabCase name}}.docs.mdx',
-				templateFile: 'templates/component/component.docs.mdx.hbs',
-				type: 'add',
-			},
-			{
-				path: '{{ turbo.paths.root }}/apps/docs/content/docs/components/{{kebabCase group}}/{{kebabCase name}}.mdx',
-				templateFile: 'templates/component/component.docs-page.mdx.hbs',
-				type: 'add',
-			},
-			addComponentToDocsMeta,
-			addComponentToDocsIndex,
-			addComponentToGettingStarted,
-			addComponentToRecipesIndex,
-			addComponentToStylesIndex,
-			syncTsdownExports,
-			() => {
-				return 'Done. @luke-ui/react exports were refreshed via tsdown.';
+			async (answers) => {
+				const input = toComponentInput(answers as ComponentAnswers);
+				const plan = createComponentPlan(input);
+				await applyComponentCreationPlan(process.cwd(), plan);
+				return `Created ${plan.expected.packageExportPath}`;
 			},
 		],
-		description: 'Scaffold a new component in @luke-ui/react',
+		description: 'Scaffold new Atom or Composed component in @luke-ui/react',
 		prompts: [
-			{
-				choices: [...DOCS_GROUPS],
-				message: 'Component group:',
-				name: 'group',
-				type: 'list',
-			},
 			{
 				message: 'Component name (PascalCase or kebab-case):',
 				name: 'name',
 				type: 'input',
 				validate: validateComponentName,
 			},
+			{
+				choices: [
+					{ name: 'Atom', value: 'atom' },
+					{ name: 'Composed', value: 'composed' },
+				],
+				message: 'Component tier:',
+				name: 'tier',
+				type: 'list',
+			},
+			{
+				choices: [...DOCS_GROUPS],
+				message: 'Docs group:',
+				name: 'docsGroup',
+				type: 'list',
+			},
+			{
+				choices: [
+					{ name: 'Recipe', value: 'recipe' },
+					{ name: 'None', value: 'none' },
+				],
+				message: 'Styling:',
+				name: 'styling',
+				type: 'list',
+			},
 		],
 	});
+}
+
+function toComponentInput(answers: ComponentAnswers): CreateComponentInput {
+	if (!answers.name) {
+		throw new Error('Component name required.');
+	}
+	if (!answers.tier) {
+		throw new Error('Component tier required.');
+	}
+	if (!answers.docsGroup) {
+		throw new Error('Docs group required.');
+	}
+	if (!answers.styling) {
+		throw new Error('Styling required.');
+	}
+	return {
+		docsGroup: answers.docsGroup,
+		name: answers.name,
+		styling: answers.styling,
+		tier: answers.tier,
+	};
+}
+
+function validateComponentName(value: unknown): true | string {
+	if (typeof value !== 'string') {
+		return 'Component name required.';
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return 'Component name required.';
+	}
+	if (!COMPONENT_NAME_RE.test(trimmed)) {
+		return 'Use letters/numbers/hyphens. Start with a letter.';
+	}
+	return true;
 }

--- a/packages/turbo-generators/package.json
+++ b/packages/turbo-generators/package.json
@@ -7,10 +7,12 @@
 		"check:lint": "vp lint . --type-aware",
 		"fix:format": "vp fmt . --write",
 		"fix:lint": "vp lint . --type-aware --fix",
-		"generate:component": "tsx scripts/generate-component.ts"
+		"generate:component": "tsx scripts/generate-component.ts",
+		"test": "vp test run"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",
-		"tsx": "catalog:"
+		"tsx": "catalog:",
+		"zod": "catalog:"
 	}
 }

--- a/packages/turbo-generators/src/apply-component-creation-plan.test.ts
+++ b/packages/turbo-generators/src/apply-component-creation-plan.test.ts
@@ -1,0 +1,103 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { z } from 'zod';
+import { applyComponentCreationPlan } from './apply-component-creation-plan.js';
+import type { ComponentCreationPlan } from './component-creation-plan.js';
+
+const roots: Array<string> = [];
+
+afterEach(async () => {
+	await Promise.all(roots.map((root) => rm(root, { force: true, recursive: true })));
+	roots.length = 0;
+});
+
+describe('applyComponentCreationPlan', () => {
+	it('writes files and applies sorted docs navigation edits idempotently', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'component-plan-'));
+		roots.push(root);
+
+		const plan: ComponentCreationPlan = {
+			expected: {
+				hostedDocsPath: 'components/feedback/status-badge',
+				packageDocsSlug: 'status-badge',
+				packageExportPath: './status-badge',
+				storySlug: 'status-badge',
+			},
+			files: [
+				{
+					contents: 'export const StatusBadge = 1;\n',
+					path: 'packages/@luke-ui/react/src/status-badge/index.tsx',
+				},
+			],
+			jsonEdits: [
+				{
+					key: 'pages',
+					kind: 'array-add-sorted',
+					path: 'apps/docs/content/docs/components/meta.json',
+					title: 'Components',
+					value: 'feedback',
+				},
+				{
+					key: 'pages',
+					kind: 'array-add-sorted',
+					path: 'apps/docs/content/docs/components/feedback/meta.json',
+					title: 'Feedback',
+					value: 'status-badge',
+				},
+			],
+		};
+
+		await applyComponentCreationPlan(root, plan);
+		await applyComponentCreationPlan(root, plan);
+
+		await expect(
+			readFile(join(root, 'packages/@luke-ui/react/src/status-badge/index.tsx'), 'utf8'),
+		).resolves.toBe('export const StatusBadge = 1;\n');
+		await expect(readJson(root, 'apps/docs/content/docs/components/meta.json')).resolves.toEqual({
+			pages: ['feedback'],
+			title: 'Components',
+		});
+		await expect(
+			readJson(root, 'apps/docs/content/docs/components/feedback/meta.json'),
+		).resolves.toEqual({
+			pages: ['status-badge'],
+			title: 'Feedback',
+		});
+	});
+
+	it('rejects docs navigation JSON that is not an object', async () => {
+		const root = await mkdtemp(join(tmpdir(), 'component-plan-'));
+		roots.push(root);
+
+		const metaPath = 'apps/docs/content/docs/components/meta.json';
+		await mkdir(join(root, 'apps/docs/content/docs/components'), { recursive: true });
+		await writeFile(join(root, metaPath), '[]\n', 'utf8');
+
+		const plan: ComponentCreationPlan = {
+			expected: {
+				hostedDocsPath: 'components/feedback/status-badge',
+				packageDocsSlug: 'status-badge',
+				packageExportPath: './status-badge',
+				storySlug: 'status-badge',
+			},
+			files: [],
+			jsonEdits: [
+				{
+					key: 'pages',
+					kind: 'array-add-sorted',
+					path: metaPath,
+					title: 'Components',
+					value: 'feedback',
+				},
+			],
+		};
+
+		await expect(applyComponentCreationPlan(root, plan)).rejects.toBeInstanceOf(z.ZodError);
+	});
+});
+
+async function readJson(root: string, path: string): Promise<unknown> {
+	return z.unknown().parse(JSON.parse(await readFile(join(root, path), 'utf8')));
+}

--- a/packages/turbo-generators/src/apply-component-creation-plan.ts
+++ b/packages/turbo-generators/src/apply-component-creation-plan.ts
@@ -1,0 +1,51 @@
+import { dirname, join } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { z } from 'zod';
+import type {
+	ComponentCreationPlan,
+	JsonArrayAddSortedEdit,
+	PlanFile,
+} from './component-creation-plan.js';
+
+const docsMetaSchema = z.record(z.string(), z.unknown());
+
+export async function applyComponentCreationPlan(
+	root: string,
+	plan: ComponentCreationPlan,
+): Promise<void> {
+	await Promise.all(plan.files.map((file) => writePlanFile(root, file)));
+	await Promise.all(plan.jsonEdits.map((edit) => applyJsonEdit(root, edit)));
+}
+
+async function writePlanFile(root: string, file: PlanFile): Promise<void> {
+	const target = join(root, file.path);
+	await mkdir(dirname(target), { recursive: true });
+	await writeFile(target, file.contents, 'utf8');
+}
+
+async function applyJsonEdit(root: string, edit: JsonArrayAddSortedEdit): Promise<void> {
+	const target = join(root, edit.path);
+	await mkdir(dirname(target), { recursive: true });
+	const data = await readJson(target, edit.title);
+	const current = data[edit.key];
+	const currentPages = Array.isArray(current) ? current.filter(isString) : [];
+	const pages = [...new Set([...currentPages, edit.value])].sort((a, b) => a.localeCompare(b));
+	data[edit.key] = pages;
+	await writeFile(target, `${JSON.stringify(data, null, '\t')}\n`, 'utf8');
+}
+
+async function readJson(path: string, title: string): Promise<Record<string, unknown>> {
+	try {
+		const json: unknown = JSON.parse(await readFile(path, 'utf8'));
+		return docsMetaSchema.parse(json);
+	} catch (err) {
+		if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+			return { title, pages: [] };
+		}
+		throw err;
+	}
+}
+
+function isString(value: unknown): value is string {
+	return typeof value === 'string';
+}

--- a/packages/turbo-generators/src/component-creation-plan.test.ts
+++ b/packages/turbo-generators/src/component-creation-plan.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { createComponentPlan } from './component-creation-plan.js';
+
+describe('createComponentPlan', () => {
+	it('plans an atom with recipe styling across package and hosted docs surfaces', () => {
+		const plan = createComponentPlan({
+			docsGroup: 'feedback',
+			name: 'StatusBadge',
+			styling: 'recipe',
+			tier: 'atom',
+		});
+
+		expect(plan.expected).toEqual({
+			hostedDocsPath: 'components/feedback/status-badge',
+			packageDocsSlug: 'status-badge',
+			packageExportPath: './status-badge',
+			storySlug: 'status-badge',
+		});
+		expect(plan.files.map((file) => file.path).sort()).toEqual([
+			'apps/docs/content/docs/components/feedback/status-badge.mdx',
+			'apps/docs/src/status-badge/status-badge.story.client.tsx',
+			'apps/docs/src/status-badge/status-badge.story.tsx',
+			'packages/@luke-ui/react/src/recipes/status-badge.css.ts',
+			'packages/@luke-ui/react/src/status-badge/index.tsx',
+			'packages/@luke-ui/react/src/status-badge/status-badge.docs.md',
+			'packages/@luke-ui/react/src/status-badge/status-badge.stories.tsx',
+		]);
+		expect(plan.jsonEdits).toEqual([
+			{
+				key: 'pages',
+				kind: 'array-add-sorted',
+				path: 'apps/docs/content/docs/components/meta.json',
+				title: 'Feedback',
+				value: 'feedback',
+			},
+			{
+				key: 'pages',
+				kind: 'array-add-sorted',
+				path: 'apps/docs/content/docs/components/feedback/meta.json',
+				title: 'Feedback',
+				value: 'status-badge',
+			},
+		]);
+		expect(
+			plan.files.find((file) => file.path.endsWith('/status-badge/index.tsx'))?.contents,
+		).toContain("export interface StatusBadgeProps extends ComponentProps<'div'> {}");
+		expect(
+			plan.files.find((file) => file.path.endsWith('/recipes/status-badge.css.ts'))?.contents,
+		).not.toContain('StatusBadgeVariants');
+	});
+
+	it('plans a composed component without recipe files', () => {
+		const plan = createComponentPlan({
+			docsGroup: 'forms',
+			name: 'DateField',
+			styling: 'none',
+			tier: 'composed',
+		});
+
+		expect(plan.files.some((file) => file.path.includes('/recipes/'))).toBe(false);
+		expect(plan.files).toContainEqual(
+			expect.objectContaining({
+				path: 'packages/@luke-ui/react/src/date-field/index.tsx',
+			}),
+		);
+	});
+
+	it('rejects invalid component names before file writes', () => {
+		expect(() =>
+			createComponentPlan({
+				docsGroup: 'forms',
+				name: '../Bad',
+				styling: 'none',
+				tier: 'atom',
+			}),
+		).toThrow('Use letters/numbers/hyphens. Start with a letter.');
+	});
+
+	it('keeps editorial docs surfaces out of the plan', () => {
+		const plan = createComponentPlan({
+			docsGroup: 'actions',
+			name: 'MenuButton',
+			styling: 'recipe',
+			tier: 'composed',
+		});
+
+		expect(plan.files.map((file) => file.path)).not.toContain('apps/docs/content/docs/index.mdx');
+		expect(plan.files.map((file) => file.path)).not.toContain(
+			'apps/docs/content/docs/getting-started.mdx',
+		);
+		expect(plan.jsonEdits.map((edit) => edit.path)).toEqual([
+			'apps/docs/content/docs/components/meta.json',
+			'apps/docs/content/docs/components/actions/meta.json',
+		]);
+	});
+});

--- a/packages/turbo-generators/src/component-creation-plan.ts
+++ b/packages/turbo-generators/src/component-creation-plan.ts
@@ -1,0 +1,276 @@
+export type ComponentTier = 'atom' | 'composed';
+export type ComponentStyling = 'none' | 'recipe';
+
+export interface CreateComponentInput {
+	docsGroup: string;
+	name: string;
+	styling: ComponentStyling;
+	tier: ComponentTier;
+}
+
+export interface PlanFile {
+	contents: string;
+	path: string;
+}
+
+export interface JsonArrayAddSortedEdit {
+	key: 'pages';
+	kind: 'array-add-sorted';
+	path: string;
+	title: string;
+	value: string;
+}
+
+export interface ComponentCreationPlan {
+	expected: {
+		hostedDocsPath: string;
+		packageDocsSlug: string;
+		packageExportPath: string;
+		storySlug: string;
+	};
+	files: Array<PlanFile>;
+	jsonEdits: Array<JsonArrayAddSortedEdit>;
+}
+
+const COMPONENT_NAME_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
+const CAMEL_BOUNDARY_RE = /([a-z0-9])([A-Z])/g;
+const NON_ALPHANUM_RE = /[^A-Za-z0-9-]/g;
+
+export function createComponentPlan(input: CreateComponentInput): ComponentCreationPlan {
+	const name = parseName(input.name);
+	const docsGroup = parseDocsGroup(input.docsGroup);
+	const displayName = toDisplayName(name);
+	const pascalName = displayName.replaceAll(' ', '');
+	const camelName = toCamelCase(name);
+	const packagePath = `@luke-ui/react/${name}`;
+
+	const files: Array<PlanFile> = [
+		{
+			contents: renderComponentSource({
+				camelName,
+				name,
+				packagePath,
+				pascalName,
+				styling: input.styling,
+				tier: input.tier,
+			}),
+			path: `packages/@luke-ui/react/src/${name}/index.tsx`,
+		},
+		{
+			contents: renderPackageDocs({ name, packagePath, pascalName }),
+			path: `packages/@luke-ui/react/src/${name}/${name}.docs.md`,
+		},
+		{
+			contents: renderPackageStory({ docsGroup, name, pascalName }),
+			path: `packages/@luke-ui/react/src/${name}/${name}.stories.tsx`,
+		},
+		{
+			contents: renderHostedStory({ name, pascalName }),
+			path: `apps/docs/src/${name}/${name}.story.tsx`,
+		},
+		{
+			contents: renderHostedStoryClient({ name, pascalName }),
+			path: `apps/docs/src/${name}/${name}.story.client.tsx`,
+		},
+		{
+			contents: renderHostedDocsPage({ displayName, name }),
+			path: `apps/docs/content/docs/components/${docsGroup}/${name}.mdx`,
+		},
+	];
+
+	if (input.styling === 'recipe') {
+		files.push({
+			contents: renderRecipe({ camelName, pascalName }),
+			path: `packages/@luke-ui/react/src/recipes/${name}.css.ts`,
+		});
+	}
+
+	return {
+		expected: {
+			hostedDocsPath: `components/${docsGroup}/${name}`,
+			packageDocsSlug: name,
+			packageExportPath: `./${name}`,
+			storySlug: name,
+		},
+		files,
+		jsonEdits: [
+			{
+				key: 'pages',
+				kind: 'array-add-sorted',
+				path: 'apps/docs/content/docs/components/meta.json',
+				title: toDisplayName(docsGroup),
+				value: docsGroup,
+			},
+			{
+				key: 'pages',
+				kind: 'array-add-sorted',
+				path: `apps/docs/content/docs/components/${docsGroup}/meta.json`,
+				title: toDisplayName(docsGroup),
+				value: name,
+			},
+		],
+	};
+}
+
+function parseName(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error('Component name required.');
+	}
+	if (!COMPONENT_NAME_RE.test(trimmed)) {
+		throw new Error('Use letters/numbers/hyphens. Start with a letter.');
+	}
+	return toKebabCase(trimmed);
+}
+
+function parseDocsGroup(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error('Docs group required.');
+	}
+	return toKebabCase(trimmed);
+}
+
+function toKebabCase(value: string): string {
+	return value
+		.trim()
+		.replaceAll(CAMEL_BOUNDARY_RE, '$1-$2')
+		.replaceAll(NON_ALPHANUM_RE, '-')
+		.toLowerCase();
+}
+
+function toDisplayName(value: string): string {
+	return toKebabCase(value)
+		.split('-')
+		.filter(Boolean)
+		.map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+		.join(' ');
+}
+
+function toCamelCase(value: string): string {
+	const [first = '', ...rest] = toKebabCase(value).split('-').filter(Boolean);
+	return `${first}${rest.map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`).join('')}`;
+}
+
+function renderComponentSource(input: {
+	camelName: string;
+	name: string;
+	packagePath: string;
+	pascalName: string;
+	styling: ComponentStyling;
+	tier: ComponentTier;
+}): string {
+	const styleImport =
+		input.styling === 'recipe'
+			? `import * as styles from '../recipes/${input.name}.css.js';\n`
+			: '';
+	const propsExtends = ` extends ComponentProps<'div'>`;
+	const className =
+		input.styling === 'recipe'
+			? ` className={cx(styles.${input.camelName}(), className)}`
+			: ' className={className}';
+
+	return `import type { ComponentProps, JSX } from 'react';
+import { cx } from '../utils/index.js';
+${styleImport}
+/** Props for \`${input.pascalName}\`.
+ *
+ * @tier ${input.tier}
+ */
+export interface ${input.pascalName}Props${propsExtends} {}
+
+/** ${input.pascalName} ${input.tier} component. */
+export function ${input.pascalName}(props: ${input.pascalName}Props): JSX.Element {
+\tconst { className, ...divProps } = props;
+\treturn <div {...divProps}${className} />;
+}
+`;
+}
+
+function renderPackageDocs(input: {
+	name: string;
+	packagePath: string;
+	pascalName: string;
+}): string {
+	return `\`${input.pascalName}\` from \`${input.packagePath}\`.
+
+## Usage
+
+\`\`\`tsx
+<${input.pascalName}>Label</${input.pascalName}>
+\`\`\`
+`;
+}
+
+function renderPackageStory(input: {
+	docsGroup: string;
+	name: string;
+	pascalName: string;
+}): string {
+	return `import { ${input.pascalName} } from '@luke-ui/react/${input.name}';
+import { expect } from 'storybook/test';
+import preview from '../../.storybook/preview.js';
+
+const meta = preview.meta({
+\tcomponent: ${input.pascalName},
+\ttags: ['${input.docsGroup}'],
+\ttitle: '${toDisplayName(input.docsGroup)}/${input.pascalName}',
+});
+
+export const Default = meta.story({
+\targs: {
+\t\tchildren: '${input.pascalName}',
+\t},
+\tplay: async ({ canvas }) => {
+\t\tawait expect(canvas.getByText('${input.pascalName}')).toBeInTheDocument();
+\t},
+});
+`;
+}
+
+function renderHostedStory(input: { name: string; pascalName: string }): string {
+	return `import type { ${input.pascalName} } from '@luke-ui/react/${input.name}';
+import { defineComponentStory } from '../lib/define-component-story';
+
+export const story = defineComponentStory<typeof ${input.pascalName}>(import.meta.url, {
+\tinitial: {
+\t\tchildren: '${input.pascalName}',
+\t},
+\tpriorities: ['children'],
+});
+`;
+}
+
+function renderHostedStoryClient(input: { name: string; pascalName: string }): string {
+	return `import { ${input.pascalName} } from '@luke-ui/react/${input.name}';
+import { createWrappedStoryClient } from '../lib/story-wrapper';
+import type { story } from './${input.name}.story';
+
+export const storyClient = createWrappedStoryClient<typeof story>(${input.pascalName});
+`;
+}
+
+function renderHostedDocsPage(input: { displayName: string; name: string }): string {
+	return `---
+title: ${input.displayName}
+description: ${input.displayName} component.
+---
+
+import { storyClient } from '../../../../src/${input.name}/${input.name}.story.client';
+
+<storyClient.WithControl />
+
+<include>../../../../../../packages/@luke-ui/react/docs/${input.name}.md</include>
+`;
+}
+
+function renderRecipe(input: { camelName: string; pascalName: string }): string {
+	return `import { recipeInLayer } from '../styles/layered-style.css.js';
+
+export const ${input.camelName} = recipeInLayer('recipes', {
+\tbase: {
+\t\tdisplay: 'inline-flex',
+\t},
+});
+`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ catalogs:
     vite-plus:
       specifier: ^0.2.1
       version: 0.2.1
+    zod:
+      specifier: ^4.4.3
+      version: 4.4.3
 
 overrides:
   vite: npm:@voidzero-dev/vite-plus-core@latest
@@ -457,6 +460,9 @@ importers:
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@types/node@26.0.1)(@vitest/browser-playwright@4.1.9)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@arethetypeswrong/core@0.18.4)(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.37)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
 
   packages/turbo-generators:
     devDependencies:
@@ -466,6 +472,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ catalog:
   '@vanilla-extract/rollup-plugin': ^1.5.3
   '@vanilla-extract/vite-plugin': ^5.2.3
   '@vitejs/plugin-react': ^6.0.3
+  zod: ^4.4.3
   '@vitest/browser-playwright': ^4.1.9
   '@vitest/coverage-v8': ^4.1.9
   '@vitest/ui': ^4.1.9

--- a/turbo.json
+++ b/turbo.json
@@ -4,8 +4,15 @@
 		"@luke-ui/react#check:lint": {
 			"dependsOn": ["build", "generate"]
 		},
+		"@luke-ui/react#check:docs": {
+			"dependsOn": ["build"]
+		},
 		"@luke-ui/react#check:types": {
 			"dependsOn": ["build", "^build"]
+		},
+		"@luke-ui/react#generate:docs": {
+			"dependsOn": ["build"],
+			"outputs": ["docs/**", "dist/docs/**"]
 		},
 		"//#check:format-root": {
 			"cache": true
@@ -53,6 +60,16 @@
 		"dev": {
 			"cache": false,
 			"dependsOn": ["generate", "^build"],
+			"persistent": true
+		},
+		"docs#build": {
+			"dependsOn": ["generate", "^build", "@luke-ui/react#generate:docs"],
+			"env": ["VITE_BASE_URL"],
+			"outputs": [".output/**", ".source/**"]
+		},
+		"docs#dev": {
+			"cache": false,
+			"dependsOn": ["generate", "^build", "@luke-ui/react#generate:docs"],
 			"persistent": true
 		},
 		"dev:storybook": {


### PR DESCRIPTION
## Summary

- move component creation rules into a tested plan module with a thin Turbo/Plop adapter
- document Component creation as domain language and record the plan-module ADR
- update @luke-ui/react build order so tsdown exports refresh before package docs generation
- add regression coverage for the package script ordering and generator output shape

## Root cause

Creating a new component can update `package.json#exports` through tsdown, but package docs were generated before `vp pack` refreshed exports. That left the docs app able to see the new export while `packages/@luke-ui/react/docs/<component>.md` did not exist yet.

## Validation

- `pnpm check`
- `pnpm test`
- `pnpm build`
- docs dev was started and reached a local URL without the missing package-doc file error
