### PR TITLE
Extract composeField helper for Composed *-Field components

### DIFF
--- a/packages/@luke-ui/react/src/combobox-field/index.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/index.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, JSX, ReactNode } from 'react';
 import type { ComboBoxProps as RacComboBoxProps } from 'react-aria-components/ComboBox';
+import { composeField } from '../field/compose-field.js';
 import type { FieldErrorProps } from '../field/primitive/error.js';
 import { Field } from '../field/primitive/index.js';
 import type { FieldNecessityIndicator } from '../field/primitive/label.js';
@@ -79,33 +80,25 @@ export interface ComboboxFieldProps<T extends object>
 
 /** Composes `ComboboxInput` with label, description, and error slots. */
 export function ComboboxField<T extends object>(props: ComboboxFieldProps<T>): JSX.Element {
+	const [fieldSlotProps, restProps] = composeField(props);
 	const {
 		children,
-		description,
-		errorMessage,
-		label,
 		listBoxProps,
 		loadMoreItem,
 		loadingState,
 		menuWidth,
-		necessityIndicator,
 		onLoadMore,
 		placeholder,
 		popoverProps,
 		size = 'medium',
 		...comboboxInputProps
-	} = props;
+	} = restProps;
 
 	const isAsync = loadingState != null;
 
 	return (
 		<ComboboxInput<T> size={size} {...comboboxInputProps}>
-			<Field
-				description={description}
-				errorMessage={errorMessage}
-				label={label}
-				necessityIndicator={necessityIndicator}
-			>
+			<Field {...fieldSlotProps}>
 				<ComboboxControl>
 					<ComboboxTextInput placeholder={placeholder} />
 					<ComboboxTrigger aria-label="Toggle options">

--- a/packages/@luke-ui/react/src/field/compose-field.ts
+++ b/packages/@luke-ui/react/src/field/compose-field.ts
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import type { FieldErrorProps } from './primitive/error.js';
+import type { FieldNecessityIndicator } from './primitive/label.js';
+
+export interface FieldSlotProps {
+	/** Optional helper text shown below the control. */
+	description?: ReactNode;
+	/** Error content passed to `FieldError`. */
+	errorMessage?: FieldErrorProps['children'];
+	/** Label content shown above the control. */
+	label?: ReactNode;
+	/** Label necessity style. */
+	necessityIndicator?: FieldNecessityIndicator;
+}
+
+/** Splits the `Field` slot props (label/description/errorMessage/necessityIndicator) off a Composed field's props. */
+export function composeField<T extends FieldSlotProps>(
+	props: T,
+): [FieldSlotProps, Omit<T, keyof FieldSlotProps>] {
+	const { description, errorMessage, label, necessityIndicator, ...restProps } = props;
+
+	return [{ description, errorMessage, label, necessityIndicator }, restProps];
+}

--- a/packages/@luke-ui/react/src/text-field/index.tsx
+++ b/packages/@luke-ui/react/src/text-field/index.tsx
@@ -4,6 +4,7 @@ import type {
 	TextFieldProps as RacTextFieldProps,
 } from 'react-aria-components/TextField';
 import { TextField as RacTextField } from 'react-aria-components/TextField';
+import { composeField } from '../field/compose-field.js';
 import type { FieldErrorProps } from '../field/primitive/error.js';
 import { Field } from '../field/primitive/index.js';
 import type { FieldNecessityIndicator } from '../field/primitive/label.js';
@@ -56,27 +57,19 @@ export interface TextFieldProps
 
 /** Composes `TextInput` with label, description, and error slots. */
 export function TextField(props: TextFieldProps): JSX.Element {
+	const [fieldSlotProps, restProps] = composeField(props);
 	const {
 		adornmentEnd,
 		adornmentStart,
-		description,
-		errorMessage,
 		inputClassName,
-		label,
-		necessityIndicator,
 		placeholder,
 		size = 'medium',
 		...textFieldProps
-	} = props;
+	} = restProps;
 
 	return (
 		<RacTextField {...textFieldProps}>
-			<Field
-				description={description}
-				errorMessage={errorMessage}
-				label={label}
-				necessityIndicator={necessityIndicator}
-			>
+			<Field {...fieldSlotProps}>
 				<TextInput
 					adornmentEnd={adornmentEnd}
 					adornmentStart={adornmentStart}


### PR DESCRIPTION
## Summary
- Add an internal `composeField()` helper (`field/compose-field.ts`, not part of `package.json#exports`) that splits the `label`/`description`/`errorMessage`/`necessityIndicator` slot props off a Composed field's props.
- `TextField` and `ComboboxField` now use the helper instead of duplicating the destructure + `<Field>` wrap inline.
- No change to public props of either component, no change to `package.json#exports`.

Closes #40

## Test plan
- [x] `tsc --noEmit` — no errors
- [x] `vp lint --type-aware` on changed files — clean
- [x] `test:unit` — 2 passed
- [x] `test:browser` — 7 passed
- [x] `test-visual.ts` (visual regression) — 106 passed, output unchanged