### PR TITLE
Exclude Storybook path from docs prerender crawl

### DIFF
--- a/apps/docs/src/routes/docs/$.tsx
+++ b/apps/docs/src/routes/docs/$.tsx
@@ -60,7 +60,11 @@ const clientLoader = browserCollections.docs.createClientLoader({
 				<DocsTitle>{frontmatter.title}</DocsTitle>
 				<DocsBody>
 					{frontmatter.description ? <blockquote>{frontmatter.description}</blockquote> : null}
-					<PageActions githubUrl={githubUrl} markdownUrl={markdownUrl} storybookUrl={storybookUrl} />
+					<PageActions
+						githubUrl={githubUrl}
+						markdownUrl={markdownUrl}
+						storybookUrl={storybookUrl}
+					/>
 					<MDX components={defaultMdxComponents} />
 				</DocsBody>
 			</DocsPage>

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -260,11 +260,15 @@ export default defineConfig(async () => {
 		packageRoot: packageRootDir,
 	});
 	const markdownPrerenderPages = await getMarkdownPrerenderPages(packageDocsCatalog);
+	const baseUrl = process.env.VITE_BASE_URL ?? '/';
+	// Storybook is copied into <base>/storybook/ by the Pages deploy workflow after this
+	// build, so the link crawler must not try to fetch it from the preview server.
+	const storybookPath = `${baseUrl.replace(/\/$/, '')}/storybook`;
 
 	return {
 		// Allow overriding the base URL for deployments to sub-paths (e.g. GitHub Pages).
 		// Set VITE_BASE_URL to the base path with a trailing slash, e.g. /luke-ui/
-		base: process.env.VITE_BASE_URL ?? '/',
+		base: baseUrl,
 		// Tell TanStack Start's plugin where the client output lives so it bakes the
 		// correct TSS_CLIENT_OUTPUT_DIR into the server bundle. Nitro's
 		// configEnvironment hook sets the resolved client env outDir to
@@ -307,7 +311,10 @@ export default defineConfig(async () => {
 				prerender: {
 					crawlLinks: true,
 					enabled: true,
-					filter: (page) => !page.path.endsWith('.mdx') && !page.path.endsWith('.md'),
+					filter: (page) =>
+						!page.path.endsWith('.mdx') &&
+						!page.path.endsWith('.md') &&
+						!page.path.startsWith(storybookPath),
 				},
 			}),
 			react(),


### PR DESCRIPTION
## Why

The `deploy-pages` job on main is failing during the docs prerender:

```
Error: Failed to fetch /luke-ui/storybook/: Not Found
```

086467a added same-origin links to `<base>/storybook/` in the nav and PageActions. The docs build prerenders with `crawlLinks: true`, so the crawler follows those links against the local preview server — but Storybook isn't part of the docs build; the workflow copies `storybook-static` into `dist/storybook` only after the build, when assembling the Pages artifact. So the crawl 404s and fails the job.

## What

Extend the prerender `filter` in `apps/docs/vite.config.ts` to skip paths under `<base>/storybook`, derived from the same `VITE_BASE_URL` the deploy workflow sets. Handles both the Pages sub-path (`/luke-ui/storybook`) and root deployments (`/storybook`).

## Verification

Ran `VITE_BASE_URL=/luke-ui/ pnpm build:docs` locally: the build completes, all docs and markdown pages still prerender, and `/luke-ui/storybook/` is no longer fetched.