### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,10 +45,12 @@ jobs:
             export TURBO_SCM_BASE="${{ github.event.pull_request.base.sha }}"
             export TURBO_SCM_HEAD="${{ github.event.pull_request.head.sha }}"
             corepack pnpm exec turbo run check:format check:lint check:types --affected
-            corepack pnpm run check:unused
+            # Run knip via turbo so //#check:unused's generate dependencies run first;
+            # bare `pnpm run check:unused` fails on PRs where --affected generated nothing.
+            corepack pnpm exec turbo run check:unused
           else
             corepack pnpm run check:format
             corepack pnpm run check:lint
             corepack pnpm run check:types
-            corepack pnpm run check:unused
+            corepack pnpm exec turbo run check:unused
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup tooling with mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install: true
           cache: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
           TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          corepack pnpm exec turbo run check:format-root check:format check:lint check:types ${{ github.event_name == 'pull_request' && '--affected' || '' }}
+          corepack pnpm exec turbo run check:format-root check:format check:lint check:types check:docs ${{ github.event_name == 'pull_request' && '--affected' || '' }}
           # knip is repo-wide, but --affected only selects packages whose own files
           # changed, so it must run unscoped. Running it via turbo (rather than the
           # bare `knip` script) pulls in its generate dependencies first.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,17 +40,13 @@ jobs:
         run: corepack pnpm install --frozen-lockfile
 
       - name: Run checks
+        env:
+          # Empty on push events; only read by --affected.
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            export TURBO_SCM_BASE="${{ github.event.pull_request.base.sha }}"
-            export TURBO_SCM_HEAD="${{ github.event.pull_request.head.sha }}"
-            corepack pnpm exec turbo run check:format check:lint check:types --affected
-            # Run knip via turbo so //#check:unused's generate dependencies run first;
-            # bare `pnpm run check:unused` fails on PRs where --affected generated nothing.
-            corepack pnpm exec turbo run check:unused
-          else
-            corepack pnpm run check:format
-            corepack pnpm run check:lint
-            corepack pnpm run check:types
-            corepack pnpm exec turbo run check:unused
-          fi
+          corepack pnpm exec turbo run check:format-root check:format check:lint check:types ${{ github.event_name == 'pull_request' && '--affected' || '' }}
+          # knip is repo-wide, but --affected only selects packages whose own files
+          # changed, so it must run unscoped. Running it via turbo (rather than the
+          # bare `knip` script) pulls in its generate dependencies first.
+          corepack pnpm exec turbo run check:unused

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       #   uses: actions/checkout@v6
 
       # - name: Setup Tooling with mise
-      #   uses: jdx/mise-action@v3
+      #   uses: jdx/mise-action@v4
 
       # - name: Enable Corepack
       #   run: corepack enable

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup tooling with mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install: true
           cache: true
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup tooling with mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install: true
           cache: true
@@ -87,7 +87,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build package
         run: corepack pnpm build:packages
@@ -124,10 +124,10 @@ jobs:
           cp -r packages/@luke-ui/react/storybook-static dist/storybook
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Why

Every job logs warnings like:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/configure-pages@v5, actions/deploy-pages@v4, actions/upload-artifact@…, jdx/mise-action@v3.

## What

Bump each action to its Node 24 major:

| Action | From | To |
|---|---|---|
| jdx/mise-action | v3 | v4 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v4 | v5 |
| actions/deploy-pages | v4 | v5 |

Checked the release notes for all four: they're runtime-only bumps with no input/behaviour changes (mise-action v4 notes call it a seamless upgrade). Also updated the commented-out reference in release.yml for consistency.

Note: `actions/checkout@v6` is already on Node 24.