### PR TITLE
Deepen the package interface catalog

### DIFF
--- a/packages/@luke-ui/docs-tools/src/discover-exports.ts
+++ b/packages/@luke-ui/docs-tools/src/discover-exports.ts
@@ -21,11 +21,6 @@ export interface DiscoveredExport {
 
 export interface DiscoverExportsOptions {
 	/**
-	 * Export specifiers to classify as `asset` (no docs page).
-	 * Defaults to {@link DEFAULT_ASSET_PATHS}, which is coupled to `@luke-ui/react`.
-	 */
-	assetPaths?: Iterable<string>;
-	/**
 	 * Export specifiers to classify as `barrel` (multi-export foundations).
 	 * Defaults to {@link DEFAULT_BARREL_PATHS}, which is coupled to `@luke-ui/react`.
 	 */
@@ -34,7 +29,10 @@ export interface DiscoverExportsOptions {
 }
 
 /**
- * Default barrel paths, coupled to `@luke-ui/react`'s public API.
+ * Default barrel paths, per the component tier taxonomy (ADR-0001) and the
+ * styling utilities public API (ADR-0004). These are foundations with more
+ * than one runtime export, so they can't be told apart from a single-export
+ * component mechanically — the list has to be maintained by hand.
  * Other consumers of `discoverExports` should pass their own via {@link DiscoverExportsOptions.barrelPaths}.
  */
 export const DEFAULT_BARREL_PATHS: ReadonlyArray<string> = [
@@ -47,31 +45,21 @@ export const DEFAULT_BARREL_PATHS: ReadonlyArray<string> = [
 	'./utils',
 ];
 
-/**
- * Default asset paths, coupled to `@luke-ui/react`'s public API.
- * Other consumers of `discoverExports` should pass their own via {@link DiscoverExportsOptions.assetPaths}.
- */
-export const DEFAULT_ASSET_PATHS: ReadonlyArray<string> = [
-	'./stylesheet.css',
-	'./spritesheet.svg',
-	'./package.json',
-];
-
 const LEADING_DOT_SLASH = /^\.\//;
 const SLASH = /\//g;
 const FILE_EXTENSION = /\.[^.]+$/;
+const JS_TARGET = /\.js$/;
 
 export function discoverExports(
 	exportsField: Record<string, string>,
 	options: DiscoverExportsOptions = {},
 ): Array<DiscoveredExport> {
 	const barrelPaths = new Set(options.barrelPaths ?? DEFAULT_BARREL_PATHS);
-	const assetPaths = new Set(options.assetPaths ?? DEFAULT_ASSET_PATHS);
 	const result: Array<DiscoveredExport> = [];
 	for (const [path, target] of Object.entries(exportsField)) {
 		let shape: ExportShape;
 		let tier: ExportTier;
-		if (assetPaths.has(path)) {
+		if (!JS_TARGET.test(target)) {
 			shape = 'asset';
 			tier = 'n/a';
 		} else if (barrelPaths.has(path)) {

--- a/packages/@luke-ui/docs-tools/src/discover-exports.ts
+++ b/packages/@luke-ui/docs-tools/src/discover-exports.ts
@@ -29,10 +29,9 @@ export interface DiscoverExportsOptions {
 }
 
 /**
- * Default barrel paths, per the component tier taxonomy (ADR-0001) and the
- * styling utilities public API (ADR-0004). These are foundations with more
- * than one runtime export, so they can't be told apart from a single-export
- * component mechanically — the list has to be maintained by hand.
+ * Default barrel paths. Some of these (e.g. `./styles`) have only one runtime
+ * export, so barrel vs. component can't be told apart mechanically and this
+ * list has to be maintained by hand.
  * Other consumers of `discoverExports` should pass their own via {@link DiscoverExportsOptions.barrelPaths}.
  */
 export const DEFAULT_BARREL_PATHS: ReadonlyArray<string> = [

--- a/packages/@luke-ui/docs-tools/src/package-docs-catalog.ts
+++ b/packages/@luke-ui/docs-tools/src/package-docs-catalog.ts
@@ -1,3 +1,9 @@
+/**
+ * `resolvePackageDocsCatalog` is the package interface catalog: the single place
+ * that resolves `package.json#exports` into classified, source-backed entries
+ * (tier, shape, description). Other tooling that needs export/tier/shape data
+ * should consume this rather than re-deriving it from `package.json` directly.
+ */
 import { existsSync } from 'node:fs';
 import type {
 	DiscoveredExport,

--- a/packages/@luke-ui/react/scripts/generate-docs.test.ts
+++ b/packages/@luke-ui/react/scripts/generate-docs.test.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_BARREL_PATHS } from '@luke-ui/docs-tools/discover-exports';
+import { describe, expect, it } from 'vite-plus/test';
+import packageJson from '../package.json' with { type: 'json' };
+
+describe('generate-docs package interface conformance', () => {
+	it('keeps DEFAULT_BARREL_PATHS in sync with the real package exports', () => {
+		const realExportPaths = new Set(Object.keys(packageJson.exports));
+		for (const barrelPath of DEFAULT_BARREL_PATHS) {
+			expect(realExportPaths.has(barrelPath)).toBe(true);
+		}
+	});
+});

--- a/packages/@luke-ui/react/vite.config.ts
+++ b/packages/@luke-ui/react/vite.config.ts
@@ -10,6 +10,7 @@ import packageJson from './package.json' with { type: 'json' };
 const workspaceRoot = fileURLToPath(new URL('../../../', import.meta.url));
 const distDir = fileURLToPath(new URL('dist/', import.meta.url));
 const preservedDistFiles = new Set(['spritesheet.svg', 'docs']);
+const assetExports = ['./stylesheet.css', './spritesheet.svg'];
 
 async function cleanDistExceptPreservedFiles() {
 	let entries: Array<string>;
@@ -36,7 +37,7 @@ export default defineConfig({
 	pack: {
 		attw: {
 			// Exclude static asset exports. CSS/SVG files do not need type definitions.
-			excludeEntrypoints: ['./stylesheet.css', './spritesheet.svg'],
+			excludeEntrypoints: assetExports,
 			profile: 'esm-only',
 		},
 		clean: false,
@@ -48,10 +49,9 @@ export default defineConfig({
 			'*': ['src/*/index.tsx', 'src/*/index.ts', 'src/*/primitive/index.tsx'],
 		},
 		exports: {
-			customExports: {
-				'./spritesheet.svg': './dist/spritesheet.svg',
-				'./stylesheet.css': './dist/stylesheet.css',
-			},
+			customExports: Object.fromEntries(
+				assetExports.map((path) => [path, `./dist/${path.slice(2)}`]),
+			),
 		},
 		format: ['esm'],
 		hooks: {

--- a/packages/@luke-ui/react/vitest.config.ts
+++ b/packages/@luke-ui/react/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 				test: {
 					environment: 'node',
 					exclude: ['**/node_modules/**', '**/*.browser.test.*'],
-					include: ['src/**/*.test.ts'],
+					include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
 					name: 'unit',
 				},
 			},


### PR DESCRIPTION
## Summary

`discover-exports.ts` decided whether a package export was an asset (CSS/SVG/package.json, no docs page) by checking it against a hardcoded list of paths. That list duplicated the asset paths already declared in `vite.config.ts`, so the two could drift out of sync. Asset detection is now based on the export target's file extension instead: anything that isn't `.js` is an asset. One less list to maintain.

`vite.config.ts` had its own duplication: the same two asset paths were written out twice, once for `attw.excludeEntrypoints` and once for `exports.customExports`. Both now read from a single `assetExports` array.

The barrel path list (`./styles`, `./recipes`, `./theme`, etc.) can't be replaced the same way. `./styles` has only one runtime export but still needs to be classified as a barrel, so export-count alone can't distinguish barrels from ordinary components. It stays hardcoded, but `generate-docs.test.ts` now checks each entry against the built `package.json#exports` and fails if one goes missing, so a rename or removal gets caught instead of drifting silently.

No behavior change. The build produces an identical `package.json#exports`, and doc generation writes the same 23 pages as before.

## Test plan

- [x] `pnpm --filter @luke-ui/docs-tools test` — 45/45 passing
- [x] `pnpm --filter @luke-ui/react run test:unit` — 4/4 passing, including the new conformance test
- [x] `pnpm --filter @luke-ui/docs-tools run check:types` and `check:lint`
- [x] `pnpm --filter @luke-ui/react run check:types:node` and `check:lint`
- [x] `pnpm --filter @luke-ui/react run build` — `package.json#exports` unchanged, `attw` and `publint` pass
- [x] `pnpm --filter @luke-ui/react run generate:docs` — same 23 pages, no classification changes