### PR TITLE
Fix generate-docs test timeout in CI

### DIFF
--- a/packages/@luke-ui/react/src/build/package-scripts.test.ts
+++ b/packages/@luke-ui/react/src/build/package-scripts.test.ts
@@ -38,18 +38,24 @@ describe('package scripts', () => {
 		expect(turboJson.tasks['docs#dev']?.dependsOn).toContain('@luke-ui/react#generate:docs');
 	});
 
-	it('removes stale generated package docs before writing current pages', async () => {
-		await mkdir(docsDir, { recursive: true });
-		await writeFile(staleDocsPath, '# stale page\n', 'utf8');
+	// Runs the real generate-docs script in a subprocess, which needs well over
+	// the default 5s test timeout.
+	it(
+		'removes stale generated package docs before writing current pages',
+		{ timeout: 60_000 },
+		async () => {
+			await mkdir(docsDir, { recursive: true });
+			await writeFile(staleDocsPath, '# stale page\n', 'utf8');
 
-		try {
-			await execFileAsync('pnpm', ['exec', 'tsx', 'scripts/generate-docs.ts'], {
-				cwd: packageRoot,
-			});
+			try {
+				await execFileAsync('pnpm', ['exec', 'tsx', 'scripts/generate-docs.ts'], {
+					cwd: packageRoot,
+				});
 
-			await expect(access(staleDocsPath)).rejects.toMatchObject({ code: 'ENOENT' });
-		} finally {
-			await rm(staleDocsPath, { force: true });
-		}
-	});
+				await expect(access(staleDocsPath)).rejects.toMatchObject({ code: 'ENOENT' });
+			} finally {
+				await rm(staleDocsPath, { force: true });
+			}
+		},
+	);
 });


### PR DESCRIPTION
## Summary

Fixes the `visual-tests` failure seen in [this CI run](https://github.com/lukebennett88/luke-ui/actions/runs/28656634471/job/84987207001), where `src/build/package-scripts.test.ts > removes stale generated package docs before writing current pages` timed out at 5000ms (it clocked in at 5006ms — just over the default).

The test deliberately runs the real `generate-docs` script end-to-end via `pnpm exec tsx`, which takes ~6s even on a warm local machine, so it structurally can't fit Vitest's default 5s timeout. This gives that one test an explicit 60s timeout to leave headroom for cold CI runners.

## Test plan

- `pnpm run test:unit` in `packages/@luke-ui/react` — all 4 tests pass, including the previously timing-out test
- `pnpm run check:format` — clean