### PR TITLE
Extract a shared input-state module behind the control recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ React design system using `vanilla-extract`.
 
 ## TODO
 
+- Revise tokens
+- Make docs more visual
+
 Components to build:
 
 ### Core

--- a/packages/@luke-ui/react/src/combobox-field/combobox-field.docs.md
+++ b/packages/@luke-ui/react/src/combobox-field/combobox-field.docs.md
@@ -19,9 +19,22 @@
 ## API Shape
 
 - Root props follow React Aria `ComboBox` naming.
-- Composed convenience props: `label`, `description`, `errorMessage`, `necessityIndicator`, `size`, `placeholder`.
+- Composed convenience props: `label`, `description`, `errorMessage`, `necessityIndicator`, `size`,
+  `placeholder`.
 - `children` renders dynamic items from `items` or `defaultItems`.
 - `listBoxProps` and `loadMoreItem` are lower-level escape hatches.
+
+## Selection indicators
+
+The selected option shows a checkmark in the listbox, and while a selection is present the control
+shows a clear button before the trigger. Pressing it clears the selection and the input text. The
+clear button is omitted when the field is disabled or read-only.
+
+```tsx
+<ComboboxField defaultValue="ca" defaultItems={countries} label="Country" name="country">
+	{(item) => <ComboboxItem>{item.label}</ComboboxItem>}
+</ComboboxField>
+```
 
 ## Required fields
 
@@ -62,8 +75,7 @@ import { Form } from 'react-aria-components';
 
 ## Async options
 
-Pass `loadingState` for built-in loading and empty states. Control options
-externally via `items`.
+Pass `loadingState` for built-in loading and empty states. Control options externally via `items`.
 
 ```tsx
 <ComboboxField
@@ -79,8 +91,7 @@ externally via `items`.
 
 ## Infinite scroll
 
-Use `onLoadMore` for automatic sentinel-based loading, or `loadMoreItem` for
-full control.
+Use `onLoadMore` for automatic sentinel-based loading, or `loadMoreItem` for full control.
 
 ```tsx
 <ComboboxField
@@ -96,14 +107,15 @@ full control.
 
 ## Primitive kit
 
-The individual `Combobox*` building blocks used to assemble `ComboboxField` are
-available for library authors who need a custom combobox layout.
+The individual `Combobox*` building blocks used to assemble `ComboboxField` are available for
+library authors who need a custom combobox layout.
 
 ```ts
 import {
 	ComboboxInput,
 	ComboboxControl,
 	ComboboxTextInput,
+	ComboboxClearButton,
 	ComboboxTrigger,
 	ComboboxPopover,
 	ComboboxListBox,
@@ -114,7 +126,7 @@ import {
 
 ### Size propagation
 
-When you set `size` on `ComboboxInput`, it is automatically inherited by
-`ComboboxControl`, `ComboboxTextInput`, `ComboboxTrigger`, `ComboboxItem`, and
-`ComboboxLoadMoreItem`. You can override the inherited size on any individual
-child by passing an explicit `size` prop to that component.
+When you set `size` on `ComboboxInput`, it is automatically inherited by `ComboboxControl`,
+`ComboboxTextInput`, `ComboboxClearButton`, `ComboboxTrigger`, `ComboboxItem`, and
+`ComboboxLoadMoreItem`. You can override the inherited size on any individual child by passing an
+explicit `size` prop to that component.

--- a/packages/@luke-ui/react/src/combobox-field/combobox-field.stories.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/combobox-field.stories.tsx
@@ -98,6 +98,46 @@ export const Uncontrolled = meta.story({
 });
 
 /**
+ * The selected option shows a checkmark in the listbox, and the control shows
+ * a clear button while a selection is present.
+ */
+export const ClearSelection = meta.story({
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const page = within(document.body);
+		const combobox = canvas.getByRole('combobox', { name: 'Country' });
+
+		// A selection is present, so the clear button renders.
+		const clearButton = canvas.getByRole('button', { name: 'Clear selection' });
+		await expect(combobox).toHaveValue('Canada');
+
+		// The selected option is marked with a checkmark.
+		await userEvent.click(combobox);
+		const selected = page.getByRole('option', { name: 'Canada' });
+		await expect(selected).toHaveAttribute('aria-selected', 'true');
+		await expect(selected.querySelector('svg')).not.toBeNull();
+
+		// Clearing resets the value and removes the clear button.
+		await userEvent.click(clearButton);
+		await expect(combobox).toHaveValue('');
+		await expect(canvas.queryByRole('button', { name: 'Clear selection' })).not.toBeInTheDocument();
+	},
+	render: function Render() {
+		return (
+			<ComboboxField
+				defaultItems={countryItems}
+				defaultValue="ca"
+				label="Country"
+				name="country"
+				placeholder="Select a country..."
+			>
+				{(item) => <ComboboxItem>{item.label}</ComboboxItem>}
+			</ComboboxField>
+		);
+	},
+});
+
+/**
  * Controlled mode uses `value`, `onChange`, and `items`.
  * The parent component manages the state.
  */

--- a/packages/@luke-ui/react/src/combobox-field/index.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/index.tsx
@@ -7,6 +7,7 @@ import type { FieldNecessityIndicator } from '../field/primitive/label.js';
 import { Icon } from '../icon/index.js';
 import { LoadingSpinner } from '../loading-spinner/index.js';
 import type { DistributiveOmit } from '../types/distributive-omit.js';
+import { ComboboxClearButton } from './primitive/clear-button.js';
 import { ComboboxControl } from './primitive/control.js';
 import { ComboboxEmptyState } from './primitive/empty-state.js';
 import { ComboboxTextInput } from './primitive/input.js';
@@ -95,14 +96,21 @@ export function ComboboxField<T extends object>(props: ComboboxFieldProps<T>): J
 	} = restProps;
 
 	const isAsync = loadingState != null;
+	const isInteractive =
+		comboboxInputProps.isDisabled !== true && comboboxInputProps.isReadOnly !== true;
 
 	return (
 		<ComboboxInput<T> size={size} {...comboboxInputProps}>
 			<Field {...fieldSlotProps}>
 				<ComboboxControl>
 					<ComboboxTextInput placeholder={placeholder} />
+					{isInteractive ? (
+						<ComboboxClearButton aria-label="Clear selection">
+							<Icon aria-hidden name="close" />
+						</ComboboxClearButton>
+					) : null}
 					<ComboboxTrigger aria-label="Toggle options">
-						<Icon aria-hidden name="chevronDown" size={size === 'small' ? 'xsmall' : 'small'} />
+						<Icon aria-hidden name="chevronDown" />
 					</ComboboxTrigger>
 				</ComboboxControl>
 				<ComboboxPopover

--- a/packages/@luke-ui/react/src/combobox-field/primitive/clear-button.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/clear-button.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react';
+import { useContext } from 'react';
 import type { ButtonProps as RacButtonProps } from 'react-aria-components/ComboBox';
-import { Button as RacButton } from 'react-aria-components/ComboBox';
+import { Button as RacButton, ComboBoxStateContext } from 'react-aria-components/ComboBox';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import { IconSizeProvider } from '../../icon-size-context/index.js';
 import * as styles from '../../recipes/combobox.css.js';
@@ -16,27 +17,41 @@ interface ComboboxStyleProps {
 }
 
 /**
- * Props for the combobox trigger button.
+ * Props for the combobox clear button.
  *
  * @tier primitive
  */
-export interface ComboboxTriggerProps
-	extends DistributiveOmit<RacButtonProps, 'className'>, ComboboxStyleProps {
+export interface ComboboxClearButtonProps
+	extends DistributiveOmit<RacButtonProps, 'className' | 'slot'>, ComboboxStyleProps {
 	className?: RacButtonProps['className'];
 }
 
-/** Trigger button used by combobox pattern. */
-export function ComboboxTrigger(props: ComboboxTriggerProps): JSX.Element {
+/** Clears the combobox selection. Renders nothing while no option is selected. */
+export function ComboboxClearButton(props: ComboboxClearButtonProps): JSX.Element | null {
 	const { size: sizeProp, ...buttonProps } = props;
 	const size = useComboboxSize(sizeProp);
+	const state = useContext(ComboBoxStateContext);
+	const hasValue = Array.isArray(state?.value) ? state.value.length > 0 : state?.value != null;
+
+	if (state == null || !hasValue) {
+		return null;
+	}
 
 	return (
 		<IconSizeProvider size={COMBOBOX_ICON_SIZE[size]}>
 			<RacButton
 				{...buttonProps}
 				className={composeRenderProps(buttonProps.className, (className) => {
-					return cx(styles.comboboxTrigger({ size }), className);
+					return cx(styles.comboboxClearButton({ size }), className);
 				})}
+				onPress={(event) => {
+					state.setValue(Array.isArray(state.value) ? [] : null);
+					state.setInputValue('');
+					buttonProps.onPress?.(event);
+				}}
+				// Opt out of the ComboBox button slot so pressing clears the selection
+				// instead of toggling the popover.
+				slot={null}
 			/>
 		</IconSizeProvider>
 	);

--- a/packages/@luke-ui/react/src/combobox-field/primitive/index.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/index.tsx
@@ -1,3 +1,5 @@
+export type { ComboboxClearButtonProps } from './clear-button.js';
+export { ComboboxClearButton } from './clear-button.js';
 export type { ComboboxControlProps } from './control.js';
 export { ComboboxControl } from './control.js';
 export type { ComboboxEmptyStateProps } from './empty-state.js';

--- a/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
@@ -8,7 +8,10 @@ import {
 	ListBoxLoadMoreItem as RacListBoxLoadMoreItem,
 } from 'react-aria-components/ComboBox';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
+import { IconSizeProvider } from '../../icon-size-context/index.js';
+import { Icon } from '../../icon/index.js';
 import * as styles from '../../recipes/combobox.css.js';
+import { COMBOBOX_ICON_SIZE } from '../../sizing/combobox-sizing.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
 import { useComboboxSize } from './size-context.js';
@@ -32,12 +35,28 @@ export function ComboboxItem<T extends object>(props: ComboboxItemProps<T>): JSX
 	const size = useComboboxSize(sizeProp);
 
 	return (
-		<RacListBoxItem
-			{...itemProps}
-			className={composeRenderProps(itemProps.className, (className) => {
-				return cx(styles.comboboxItem({ size }), className);
-			})}
-		/>
+		<IconSizeProvider size={COMBOBOX_ICON_SIZE[size]}>
+			<RacListBoxItem
+				// The children wrapper below is a render function, which disables RAC's
+				// own string-children textValue inference — so re-derive it here.
+				textValue={typeof itemProps.children === 'string' ? itemProps.children : undefined}
+				{...itemProps}
+				className={composeRenderProps(itemProps.className, (className) => {
+					return cx(styles.comboboxItem({ size }), className);
+				})}
+			>
+				{composeRenderProps(itemProps.children, (children, { isSelected }) => {
+					return (
+						<>
+							{children}
+							{isSelected ? (
+								<Icon aria-hidden className={styles.comboboxItemCheck} name="check" />
+							) : null}
+						</>
+					);
+				})}
+			</RacListBoxItem>
+		</IconSizeProvider>
 	);
 }
 

--- a/packages/@luke-ui/react/src/recipes/combobox.css.ts
+++ b/packages/@luke-ui/react/src/recipes/combobox.css.ts
@@ -112,7 +112,7 @@ export const comboboxTrigger = recipeInLayer('recipes', {
 
 		selectors: {
 			'&:not(:first-child)': {
-				backgroundColor: vars.backgroundColor.subtle,
+				backgroundColor: 'transparent',
 				inlineSize: 'auto',
 			},
 			'&:not(:first-child)::before': {
@@ -163,6 +163,50 @@ export const comboboxTrigger = recipeInLayer('recipes', {
 			},
 		},
 	},
+});
+
+export const comboboxClearButton = recipeInLayer('recipes', {
+	base: {
+		alignItems: 'center',
+		appearance: 'none',
+		backgroundColor: 'transparent',
+		border: 'none',
+		color: vars.foregroundColor.secondary,
+		cursor: 'pointer',
+		display: 'inline-flex',
+		flexShrink: 0,
+		justifyContent: 'center',
+
+		selectors: {
+			'&:where([data-hovered="true"], :hover)': {
+				color: vars.foregroundColor.primary,
+			},
+			'&:where([data-disabled="true"], :disabled)': {
+				color: vars.foregroundColor.disabled,
+				cursor: 'not-allowed',
+			},
+		},
+	},
+	defaultVariants: {
+		size: 'medium',
+	},
+	variants: {
+		size: {
+			medium: {
+				blockSize: vars.controlSize.medium,
+				paddingInline: vars.space.xsmall,
+			},
+			small: {
+				blockSize: vars.controlSize.small,
+				paddingInline: vars.space.xxsmall,
+			},
+		},
+	},
+});
+
+export const comboboxItemCheck = styleInLayer('recipes', {
+	flexShrink: 0,
+	marginInlineStart: 'auto',
 });
 
 export const comboboxPopover = recipeInLayer('recipes', {
@@ -270,17 +314,25 @@ export const comboboxItem = recipeInLayer('recipes', {
 		lineHeight: vars.font.lineHeight.tight,
 		minInlineSize: 0,
 		outline: 'none',
+		'@media': {
+			'(forced-colors: active)': {
+				selectors: {
+					// Forced colors strips background highlights, so the active option
+					// gets a ring there — it's the only possible indicator.
+					'&[data-focus-visible="true"]': {
+						outlineColor: 'Highlight',
+						outlineOffset: '-2px',
+						outlineStyle: 'solid',
+						outlineWidth: '2px',
+					},
+				},
+			},
+		},
 
 		selectors: {
 			'&[data-disabled="true"]': {
 				color: vars.foregroundColor.disabled,
 				cursor: 'not-allowed',
-			},
-			'&[data-focus-visible="true"]': {
-				outlineColor: vars.themeColor.focusRingColor,
-				outlineOffset: 0,
-				outlineStyle: 'solid',
-				outlineWidth: '3px',
 			},
 			'&[data-focused="true"]:not([data-disabled="true"])': {
 				backgroundColor: vars.backgroundColor.hover,
@@ -288,6 +340,13 @@ export const comboboxItem = recipeInLayer('recipes', {
 			'&[data-selected="true"]:not([data-disabled="true"])': {
 				backgroundColor: vars.backgroundColor.subtle,
 				fontWeight: vars.font.weight.medium,
+			},
+			// DOM focus stays on the input (aria-activedescendant), which shows the
+			// only focus ring; the keyboard-active option is indicated by a
+			// background one step stronger than hover, not a second ring. Declared
+			// after the focused/selected backgrounds so it wins on the same option.
+			'&[data-focus-visible="true"]:not([data-disabled="true"])': {
+				backgroundColor: vars.backgroundColor.pressed,
 			},
 		},
 	},

--- a/packages/@luke-ui/react/src/recipes/combobox.css.ts
+++ b/packages/@luke-ui/react/src/recipes/combobox.css.ts
@@ -277,7 +277,7 @@ export const comboboxItem = recipeInLayer('recipes', {
 				cursor: 'not-allowed',
 			},
 			'&[data-focus-visible="true"]': {
-				outlineColor: vars.themeColor.paletteThemePrimary200,
+				outlineColor: vars.themeColor.focusRingColor,
 				outlineOffset: 0,
 				outlineStyle: 'solid',
 				outlineWidth: '3px',

--- a/packages/@luke-ui/react/src/recipes/combobox.css.ts
+++ b/packages/@luke-ui/react/src/recipes/combobox.css.ts
@@ -1,25 +1,18 @@
 import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipeInLayer, styleInLayer } from '../styles/layered-style.css.js';
 import { vars } from '../styles/vars.css.js';
+import { descendantDisabledSelector, inputChromeStyles, inputStates } from './input-states.css.js';
 
-const transitionProperty = 'color, background-color, border-color';
-
-const disabledState =
-	'[data-disabled="true"], [aria-disabled="true"], :has(input:disabled), :has(button:disabled), :has([data-disabled="true"])';
-const descendantDisabledState = '[data-disabled="true"], [aria-disabled="true"]';
-const focusWithinState = '[data-focus-within="true"], [data-focused="true"], :focus-within';
-const hoverState = '[data-hovered="true"], :hover';
-const invalidState =
-	'[data-invalid="true"], [aria-invalid="true"], :has(:invalid), :has(input[aria-invalid="true"]), :has([data-invalid="true"]), :has([aria-invalid="true"])';
-const readOnlyState = '[data-readonly="true"], :has(:read-only)';
-
-const controlDisabledSelector = `&:where(${disabledState})`;
-const controlFocusWithinSelector = `&:where(${focusWithinState})`;
-const controlHoverSelector = `&:where(${hoverState}):not(:where(${disabledState})):not(:where(${focusWithinState}))`;
-const controlInvalidSelector = `&:where(${invalidState})`;
-const controlInvalidFocusWithinSelector = `&:where(${invalidState}):where(${focusWithinState})`;
-const controlReadOnlySelector = `&:where(${readOnlyState})`;
-const descendantDisabledSelector = `:where(${descendantDisabledState}) &`;
+/**
+ * The combobox control is a group wrapping an input and a trigger button, and
+ * unlike a text field's group it does not receive RAC's field data attributes
+ * itself — so state detection extends the defaults to also watch descendants.
+ */
+const comboboxStates = {
+	...inputStates,
+	disabled: `${inputStates.disabled}, :has(button:disabled), :has([data-disabled="true"])`,
+	invalid: `${inputStates.invalid}, :has([data-invalid="true"]), :has([aria-invalid="true"])`,
+};
 
 export const comboboxRoot = styleInLayer('recipes', {
 	display: 'flex',
@@ -29,56 +22,9 @@ export const comboboxRoot = styleInLayer('recipes', {
 });
 
 export const comboboxControl = recipeInLayer('recipes', {
-	base: {
-		alignItems: 'center',
-		backgroundColor: vars.backgroundColor.input,
-		borderColor: vars.border.input,
-		borderRadius: vars.borderRadius.medium,
-		borderStyle: 'solid',
-		borderWidth: vars.borderWidth.thin,
-		color: vars.themeColor.inputColor,
-		display: 'inline-flex',
-		fontFamily: vars.font.family.body,
-		inlineSize: '100%',
-		minInlineSize: 0,
-		overflow: 'hidden',
-
-		selectors: {
-			[controlDisabledSelector]: {
-				backgroundColor: vars.backgroundColor.inputDisabled,
-				borderColor: vars.border.default,
-				color: vars.foregroundColor.disabled,
-				cursor: 'not-allowed',
-			},
-			[controlHoverSelector]: {
-				borderColor: vars.themeColor.paletteThemePrimary400,
-			},
-			[controlFocusWithinSelector]: {
-				borderColor: vars.themeColor.paletteThemePrimary500,
-				outlineColor: vars.themeColor.paletteThemePrimary200,
-				outlineOffset: 0,
-				outlineStyle: 'solid',
-				outlineWidth: '3px',
-			},
-			[controlInvalidSelector]: {
-				borderColor: vars.border.critical,
-				outlineStyle: 'none',
-			},
-			[controlInvalidFocusWithinSelector]: {
-				borderColor: vars.border.critical,
-				outlineColor: vars.themeColor.paletteThemePrimary200,
-				outlineOffset: 0,
-				outlineStyle: 'solid',
-				outlineWidth: '3px',
-			},
-			[controlReadOnlySelector]: {
-				backgroundColor: vars.backgroundColor.subtle,
-			},
-		},
-		transitionDuration: vars.motion.duration.fast,
-		transitionProperty,
-		transitionTimingFunction: vars.motion.easing.standard,
-	},
+	// Unlike the text input's borderless disabled look, the disabled combobox
+	// control keeps a visible border.
+	base: inputChromeStyles(comboboxStates, { disabledBorderColor: vars.border.default }),
 	defaultVariants: {
 		size: 'medium',
 	},

--- a/packages/@luke-ui/react/src/recipes/input-states.browser.test.ts
+++ b/packages/@luke-ui/react/src/recipes/input-states.browser.test.ts
@@ -89,11 +89,18 @@ test('text input and combobox share the same focus ring color', () => {
 	expect(controlOutline).toBe(groupOutline);
 });
 
-test('combobox items share the control focus ring color', () => {
+test('keyboard-focused combobox items are indicated by background, not a second ring', () => {
 	const item = document.createElement('li');
 	item.className = comboboxItem({ size: 'medium' });
+	// RAC marks the keyboard-active option with both attributes.
+	item.setAttribute('data-focused', 'true');
 	item.setAttribute('data-focus-visible', 'true');
 	mount(item);
 
-	expect(getComputedStyle(item).outlineColor).toBe(resolveColor(vars.themeColor.focusRingColor));
+	const style = getComputedStyle(item);
+	expect(style.outlineStyle).toBe('none');
+	expect(style.backgroundColor).toBe(resolveColor(vars.backgroundColor.pressed));
+	// The keyboard indicator carries the whole job without a ring, so it must
+	// stay distinguishable from a plain hover highlight.
+	expect(style.backgroundColor).not.toBe(resolveColor(vars.backgroundColor.hover));
 });

--- a/packages/@luke-ui/react/src/recipes/input-states.browser.test.ts
+++ b/packages/@luke-ui/react/src/recipes/input-states.browser.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from 'vite-plus/test';
 import { themeClass, vars } from '../styles/vars.css.js';
-import { comboboxControl } from './combobox.css.js';
+import { comboboxControl, comboboxItem } from './combobox.css.js';
 import { textInputAdornmentStart, textInputGroup } from './text-input.css.js';
 
 let wrappers: Array<HTMLElement> = [];
@@ -87,4 +87,13 @@ test('text input and combobox share the same focus ring color', () => {
 
 	expect(groupOutline).toBe(resolveColor(vars.themeColor.focusRingColor));
 	expect(controlOutline).toBe(groupOutline);
+});
+
+test('combobox items share the control focus ring color', () => {
+	const item = document.createElement('li');
+	item.className = comboboxItem({ size: 'medium' });
+	item.setAttribute('data-focus-visible', 'true');
+	mount(item);
+
+	expect(getComputedStyle(item).outlineColor).toBe(resolveColor(vars.themeColor.focusRingColor));
 });

--- a/packages/@luke-ui/react/src/recipes/input-states.browser.test.ts
+++ b/packages/@luke-ui/react/src/recipes/input-states.browser.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, expect, test } from 'vite-plus/test';
+import { themeClass, vars } from '../styles/vars.css.js';
+import { comboboxControl } from './combobox.css.js';
+import { textInputAdornmentStart, textInputGroup } from './text-input.css.js';
+
+let wrappers: Array<HTMLElement> = [];
+
+function mount(control: HTMLElement): HTMLElement {
+	// Token vars only resolve inside the theme class.
+	const wrapper = document.body.appendChild(document.createElement('div'));
+	wrapper.className = themeClass;
+	wrappers.push(wrapper);
+	wrapper.append(control);
+	return control;
+}
+
+/** Resolves a token's `var()` reference to the computed color Chromium reports. */
+function resolveColor(value: string): string {
+	const probe = document.createElement('div');
+	probe.style.backgroundColor = value;
+	const mounted = mount(probe);
+	return getComputedStyle(mounted).backgroundColor;
+}
+
+function comboboxControlElement() {
+	const control = document.createElement('div');
+	control.className = comboboxControl({ size: 'medium' });
+	control.append(document.createElement('input'), document.createElement('button'));
+	return control;
+}
+
+afterEach(() => {
+	for (const wrapper of wrappers) {
+		wrapper.remove();
+	}
+	wrappers = [];
+});
+
+test('a resting combobox control is not styled as read-only by its trigger button', () => {
+	const control = mount(comboboxControlElement());
+
+	// `:has(:read-only)` would match the trigger button; `:has(input:read-only)` must not.
+	expect(getComputedStyle(control).backgroundColor).toBe(resolveColor(vars.backgroundColor.input));
+});
+
+test('a resting text input group is not styled as read-only by its adornment', () => {
+	const group = document.createElement('div');
+	group.className = textInputGroup({ size: 'medium' });
+	const adornment = document.createElement('span');
+	adornment.className = textInputAdornmentStart({ size: 'medium' });
+	group.append(adornment, document.createElement('input'));
+	mount(group);
+
+	expect(getComputedStyle(group).backgroundColor).toBe(resolveColor(vars.backgroundColor.input));
+});
+
+test('a combobox control with a read-only input gets the read-only treatment', () => {
+	const control = comboboxControlElement();
+	control.querySelector('input')?.setAttribute('readonly', '');
+	mount(control);
+
+	expect(getComputedStyle(control).backgroundColor).toBe(resolveColor(vars.backgroundColor.subtle));
+});
+
+test('disabled beats read-only on a combobox control', () => {
+	const control = comboboxControlElement();
+	// A disabled input also matches `:read-only`; the disabled treatment must win.
+	control.querySelector('input')?.setAttribute('disabled', '');
+	mount(control);
+
+	const style = getComputedStyle(control);
+	expect(style.backgroundColor).toBe(resolveColor(vars.backgroundColor.inputDisabled));
+	expect(style.borderColor).toBe(resolveColor(vars.border.default));
+});
+
+test('text input and combobox share the same focus ring color', () => {
+	const group = document.createElement('div');
+	group.className = textInputGroup({ size: 'medium' });
+	group.append(document.createElement('input'));
+	mount(group);
+	const control = mount(comboboxControlElement());
+
+	group.querySelector('input')?.focus();
+	const groupOutline = getComputedStyle(group).outlineColor;
+	control.querySelector('input')?.focus();
+	const controlOutline = getComputedStyle(control).outlineColor;
+
+	expect(groupOutline).toBe(resolveColor(vars.themeColor.focusRingColor));
+	expect(controlOutline).toBe(groupOutline);
+});

--- a/packages/@luke-ui/react/src/recipes/input-states.css.ts
+++ b/packages/@luke-ui/react/src/recipes/input-states.css.ts
@@ -1,0 +1,134 @@
+import type { StyleRule } from '@vanilla-extract/css';
+import { vars } from '../styles/vars.css.js';
+
+/**
+ * State definitions shared by field control recipes (the `TextInput` group,
+ * the Combobox control): each entry lists every selector that means "this
+ * control is in state X".
+ *
+ * The defaults cover a RAC `Group` that carries the field's data attributes
+ * itself and contains a single `input`. Anatomies with more parts extend
+ * these — see `combobox.css.ts`, which also watches its trigger button.
+ */
+export const inputStates = {
+	disabled:
+		'[data-disabled="true"], [aria-disabled="true"], :has(input:disabled), :has(input[aria-disabled="true"])',
+	focusWithin: '[data-focus-within="true"], :focus-within',
+	hover: '[data-hovered="true"], :hover',
+	invalid:
+		'[data-invalid="true"], [aria-invalid="true"], :has(:invalid), :has(input[aria-invalid="true"])',
+	// Scoped to `input` deliberately: bare `:read-only` matches any non-editable
+	// element (spans, buttons), so `:has(:read-only)` would match any control
+	// that contains an adornment or trigger.
+	readOnly: '[data-readonly="true"], :has(input:read-only)',
+};
+
+/** State definitions consumed by {@link inputChromeStyles}. */
+export type InputStates = typeof inputStates;
+
+/** Only explicit disabled attrs; avoids `:has()` matching an ancestor that contains any disabled input on the page. */
+const descendantDisabledState = '[data-disabled="true"], [aria-disabled="true"]';
+
+/** Selector for parts styled by a disabled ancestor (adornments, triggers). */
+export const descendantDisabledSelector = `:where(${descendantDisabledState}) &`;
+
+function composeInputStateSelectors(states: InputStates) {
+	const disabled = `&:where(${states.disabled})`;
+	return {
+		disabled,
+		focusWithin: `&:where(${states.focusWithin})`,
+		hover: `&:where(${states.hover}):not(:where(${states.disabled})):not(:where(${states.focusWithin}))`,
+		invalid: `&:where(${states.invalid})`,
+		invalidFocusWithin: `&:where(${states.invalid}):where(${states.focusWithin})`,
+		readOnly: `&:where(${states.readOnly}):not(:where(${states.disabled}))`,
+	};
+}
+
+interface InputChromeOptions {
+	/** Border color for the disabled state. */
+	disabledBorderColor?: string;
+}
+
+/**
+ * Complete base style for a field control group: resting chrome plus
+ * disabled / hover / focus-within / invalid / read-only treatments and
+ * forced-colors support.
+ */
+export function inputChromeStyles(
+	states: InputStates,
+	options: InputChromeOptions = {},
+): StyleRule {
+	const selectors = composeInputStateSelectors(states);
+	const { disabledBorderColor = vars.backgroundColor.inputDisabled } = options;
+
+	return {
+		'@media': {
+			'(forced-colors: active)': {
+				selectors: {
+					[selectors.focusWithin]: {
+						outlineColor: 'Highlight',
+					},
+					[selectors.invalid]: {
+						borderColor: 'ButtonText',
+					},
+					[selectors.invalidFocusWithin]: {
+						borderColor: 'ButtonText',
+						outlineColor: 'Highlight',
+					},
+					[selectors.disabled]: {
+						borderColor: 'GrayText',
+						color: 'GrayText',
+					},
+				},
+			},
+		},
+		alignItems: 'center',
+		backgroundColor: vars.backgroundColor.input,
+		borderColor: vars.border.input,
+		borderRadius: vars.borderRadius.medium,
+		borderStyle: 'solid',
+		borderWidth: vars.borderWidth.thin,
+		color: vars.themeColor.inputColor,
+		display: 'inline-flex',
+		fontFamily: vars.font.family.body,
+		inlineSize: '100%',
+		minInlineSize: 0,
+		overflow: 'hidden',
+
+		selectors: {
+			[selectors.disabled]: {
+				backgroundColor: vars.backgroundColor.inputDisabled,
+				borderColor: disabledBorderColor,
+				color: vars.foregroundColor.disabled,
+				cursor: 'not-allowed',
+			},
+			[selectors.hover]: {
+				borderColor: vars.themeColor.paletteThemePrimary400,
+			},
+			[selectors.focusWithin]: {
+				borderColor: vars.themeColor.paletteThemePrimary500,
+				outlineColor: vars.themeColor.focusRingColor,
+				outlineOffset: 0,
+				outlineStyle: 'solid',
+				outlineWidth: '3px',
+			},
+			[selectors.invalid]: {
+				borderColor: vars.border.critical,
+				outlineStyle: 'none',
+			},
+			[selectors.invalidFocusWithin]: {
+				borderColor: vars.border.critical,
+				outlineColor: vars.themeColor.focusRingColor,
+				outlineOffset: 0,
+				outlineStyle: 'solid',
+				outlineWidth: '3px',
+			},
+			[selectors.readOnly]: {
+				backgroundColor: vars.backgroundColor.subtle,
+			},
+		},
+		transitionDuration: vars.motion.duration.fast,
+		transitionProperty: 'color, background-color, border-color',
+		transitionTimingFunction: vars.motion.easing.standard,
+	};
+}

--- a/packages/@luke-ui/react/src/recipes/text-input.css.ts
+++ b/packages/@luke-ui/react/src/recipes/text-input.css.ts
@@ -1,99 +1,13 @@
 import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipeInLayer } from '../styles/layered-style.css.js';
 import { vars } from '../styles/vars.css.js';
-
-const transitionProperty = 'color, background-color, border-color';
-
-const disabledState =
-	'[data-disabled="true"], [aria-disabled="true"], :has(input:disabled), :has(input[aria-disabled="true"])';
-/** Only explicit disabled attrs; avoids :has() matching an ancestor that contains any disabled input on the page. */
-const descendantDisabledState = '[data-disabled="true"], [aria-disabled="true"]';
-const focusWithinState = '[data-focus-within="true"], :focus-within';
-const hoverState = '[data-hovered="true"], :hover';
-const invalidState =
-	'[data-invalid="true"], [aria-invalid="true"], :has(:invalid), :has(input[aria-invalid="true"])';
-const readOnlyState = '[data-readonly="true"], :has(:read-only)';
-
-const groupDisabledSelector = `&:where(${disabledState})`;
-const groupHoverSelector = `&:where(${hoverState}):not(:where(${disabledState})):not(:where(${focusWithinState}))`;
-const groupFocusWithinSelector = `&:where(${focusWithinState})`;
-const groupInvalidSelector = `&:where(${invalidState})`;
-const groupInvalidFocusWithinSelector = `&:where(${invalidState}):where(${focusWithinState})`;
-const groupReadOnlySelector = `&:where(${readOnlyState})`;
-const descendantDisabledSelector = `:where(${descendantDisabledState}) &`;
+import { descendantDisabledSelector, inputChromeStyles, inputStates } from './input-states.css.js';
 
 /** Vanilla-extract recipe for the `TextInput` group styles. */
 export const textInputGroup = recipeInLayer('recipes', {
 	base: {
-		'@media': {
-			'(forced-colors: active)': {
-				selectors: {
-					[groupFocusWithinSelector]: {
-						outlineColor: 'Highlight',
-					},
-					[groupInvalidSelector]: {
-						borderColor: 'ButtonText',
-					},
-					[groupInvalidFocusWithinSelector]: {
-						borderColor: 'ButtonText',
-						outlineColor: 'Highlight',
-					},
-					[groupDisabledSelector]: {
-						borderColor: 'GrayText',
-						color: 'GrayText',
-					},
-				},
-			},
-		},
-		alignItems: 'center',
-		backgroundColor: vars.backgroundColor.input,
-		borderColor: vars.border.input,
-		borderRadius: vars.borderRadius.medium,
-		borderStyle: 'solid',
-		borderWidth: vars.borderWidth.thin,
-		color: vars.themeColor.inputColor,
+		...inputChromeStyles(inputStates),
 		cursor: 'text',
-		display: 'inline-flex',
-		fontFamily: vars.font.family.body,
-		inlineSize: '100%',
-		minInlineSize: 0,
-		overflow: 'hidden',
-
-		selectors: {
-			[groupDisabledSelector]: {
-				backgroundColor: vars.backgroundColor.inputDisabled,
-				borderColor: vars.backgroundColor.inputDisabled,
-				color: vars.foregroundColor.disabled,
-				cursor: 'not-allowed',
-			},
-			[groupHoverSelector]: {
-				borderColor: vars.themeColor.paletteThemePrimary400,
-			},
-			[groupFocusWithinSelector]: {
-				borderColor: vars.themeColor.paletteThemePrimary500,
-				outlineColor: vars.themeColor.focusRingColor,
-				outlineOffset: 0,
-				outlineStyle: 'solid',
-				outlineWidth: '3px',
-			},
-			[groupInvalidSelector]: {
-				borderColor: vars.border.critical,
-				outlineStyle: 'none',
-			},
-			[groupInvalidFocusWithinSelector]: {
-				borderColor: vars.border.critical,
-				outlineColor: vars.themeColor.focusRingColor,
-				outlineOffset: 0,
-				outlineStyle: 'solid',
-				outlineWidth: '3px',
-			},
-			[groupReadOnlySelector]: {
-				backgroundColor: vars.backgroundColor.subtle,
-			},
-		},
-		transitionDuration: vars.motion.duration.fast,
-		transitionProperty,
-		transitionTimingFunction: vars.motion.easing.standard,
 	},
 	defaultVariants: {
 		size: 'medium',

--- a/packages/@luke-ui/react/src/sizing/combobox-sizing.ts
+++ b/packages/@luke-ui/react/src/sizing/combobox-sizing.ts
@@ -1,0 +1,7 @@
+import type { IconSizeToken } from '../tokens/index.js';
+
+/** Maps combobox control size to the appropriate icon size. */
+export const COMBOBOX_ICON_SIZE: Record<'medium' | 'small', IconSizeToken> = {
+	medium: 'small',
+	small: 'xsmall',
+};

--- a/packages/@luke-ui/react/vitest.config.ts
+++ b/packages/@luke-ui/react/vitest.config.ts
@@ -30,6 +30,10 @@ export default defineConfig({
 			},
 			{
 				extends: true,
+				plugins: [
+					// Required for .css.ts processing in Vitest browser mode.
+					vanillaExtractPlugin(),
+				],
 				test: {
 					browser: {
 						enabled: true,


### PR DESCRIPTION
## Summary

`text-input.css.ts` and `combobox.css.ts` each maintained their own copy of the disabled / hover / focus-within / invalid / read-only selector constants and state treatments, and the copies had drifted (different focus-ring tokens; `forced-colors` support on only one). This extracts a shared module, `recipes/input-states.css.ts`, that owns the state definitions (`inputStates`) and the complete control chrome (`inputChromeStyles`). Both recipes consume it, so divergence is now a deliberate override at the seam instead of an accident. The module is internal — nothing is added to the public `@luke-ui/react/recipes` barrel.

The combobox extends state detection explicitly (its group wraps an input *and* a trigger button and doesn't receive RAC's field data attributes itself) and keeps its visible disabled border as a deliberate override, with a comment saying so.

## Deliberate behaviour changes (Argos will flag these)

- **Combobox focus ring** now uses the `focusRingColor` token — it was hardcoded to `paletteThemePrimary200`, one shade lighter than the text input's ring.
- **Combobox gains `forced-colors` treatments** (focus/invalid/disabled) that only the text input had.
- **Read-only detection scoped to `:has(input:read-only)`.** Bare `:read-only` matches *any* non-editable element (spans, buttons), so every combobox control (via its trigger button) and every adorned text input group matched the read-only state unconditionally — rendering `neutralSubtle` (#fafafa) instead of `input` (white) at rest. Resting controls are now white.
- **Read-only no longer overrides disabled.** A disabled input also matches `:read-only`; the two backgrounds share a value today, so this pins semantics rather than changing pixels.
- **Combobox item focus ring** also unified to `focusRingColor` — it was the last ring hardcoded to `paletteThemePrimary200`, so a focused listbox item rendered one shade lighter than the focused control above it.
- **Dropped `[data-focused="true"]` from the combobox focus-within state** — RAC `Group` never emits `data-focused`, so the selector was dead.

## Tests

New `input-states.browser.test.ts` runs against the compiled recipes in real Chromium and asserts computed styles through the recipes' interface: resting controls aren't styled read-only by their trigger/adornment, a read-only input does get the treatment, disabled beats read-only, and both recipes resolve the same focus-ring colour. To support it, the browser vitest project now loads `vanillaExtractPlugin()` like the unit and storybook projects already did.

Verified with `turbo run build check` (build, format, lint, types, docs) and both vitest projects. Two pre-existing local failures are unrelated: root knip and the `package-scripts.test.ts` timeout both trip over the in-progress `.claude/worktrees/fix-package-scripts-test-timeout` worktree / the issue it exists to fix.


## Follow-up: listbox focus treatment + combobox selection UX

Iteration on review feedback, in later commits:

- **Listbox option focus is highlight-only.** The keyboard-active option gets a background one step stronger than hover (`neutralPressed`) instead of any ring — DOM focus stays on the input (`aria-activedescendant`), so the control shows the only focus ring. Forced-colors mode keeps a 2px inset ring on the active option since backgrounds are stripped there. The browser test pins that the keyboard highlight stays distinguishable from plain hover.
- **Selected option shows a trailing checkmark** (Park UI shape). `ComboboxItem` re-derives `textValue` for string children since the checkmark wrapper is a render function.
- **New `ComboboxClearButton` primitive**, exported from the kit and rendered by `ComboboxField` before the trigger while a selection is present (omitted when disabled/read-only). Uses the modern `ComboBoxState` `value`/`setValue` API — `selectedKey`/`setSelectedKey` are deprecated in RAC.
- **Trigger box no longer darker than the input** — its non-first-child background is transparent instead of `subtle`.
- **`COMBOBOX_ICON_SIZE` in `sizing/`**, provided via `IconSizeProvider` by the trigger, clear button, and item — callers no longer pass icon sizes and the mapping is deliberately distinct from `BUTTON_ICON_SIZE` in one inspectable place.
