### PR TITLE
Use size?: ComboboxSize directly in five combobox primitives

### DIFF
--- a/packages/@luke-ui/react/src/combobox-field/primitive/clear-button.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/clear-button.tsx
@@ -8,13 +8,8 @@ import * as styles from '../../recipes/combobox.css.js';
 import { COMBOBOX_ICON_SIZE } from '../../sizing/combobox-sizing.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import type { ComboboxSize } from './root.js';
 import { useComboboxSize } from './size-context.js';
-
-interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
-
-interface ComboboxStyleProps {
-	size?: ComboboxVariantProps['size'];
-}
 
 /**
  * Props for the combobox clear button.
@@ -22,8 +17,9 @@ interface ComboboxStyleProps {
  * @tier primitive
  */
 export interface ComboboxClearButtonProps
-	extends DistributiveOmit<RacButtonProps, 'className' | 'slot'>, ComboboxStyleProps {
+	extends DistributiveOmit<RacButtonProps, 'className' | 'slot'> {
 	className?: RacButtonProps['className'];
+	size?: ComboboxSize;
 }
 
 /** Clears the combobox selection. Renders nothing while no option is selected. */

--- a/packages/@luke-ui/react/src/combobox-field/primitive/clear-button.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/clear-button.tsx
@@ -16,8 +16,10 @@ import { useComboboxSize } from './size-context.js';
  *
  * @tier primitive
  */
-export interface ComboboxClearButtonProps
-	extends DistributiveOmit<RacButtonProps, 'className' | 'slot'> {
+export interface ComboboxClearButtonProps extends DistributiveOmit<
+	RacButtonProps,
+	'className' | 'slot'
+> {
 	className?: RacButtonProps['className'];
 	size?: ComboboxSize;
 }

--- a/packages/@luke-ui/react/src/combobox-field/primitive/control.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/control.tsx
@@ -5,14 +5,8 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../../recipes/combobox.css.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import type { ComboboxSize } from './root.js';
 import { useComboboxSize } from './size-context.js';
-
-interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
-
-interface ComboboxStyleProps {
-	/** Control size. */
-	size?: ComboboxVariantProps['size'];
-}
 
 /**
  * Props for the styled combobox control group.
@@ -20,8 +14,9 @@ interface ComboboxStyleProps {
  * @tier primitive
  */
 export interface ComboboxControlProps
-	extends DistributiveOmit<RacGroupProps, 'className'>, ComboboxStyleProps {
+	extends DistributiveOmit<RacGroupProps, 'className'> {
 	className?: RacGroupProps['className'];
+	size?: ComboboxSize;
 }
 
 /** Control wrapper for combobox text input + trigger content. */

--- a/packages/@luke-ui/react/src/combobox-field/primitive/control.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/control.tsx
@@ -13,8 +13,7 @@ import { useComboboxSize } from './size-context.js';
  *
  * @tier primitive
  */
-export interface ComboboxControlProps
-	extends DistributiveOmit<RacGroupProps, 'className'> {
+export interface ComboboxControlProps extends DistributiveOmit<RacGroupProps, 'className'> {
 	className?: RacGroupProps['className'];
 	size?: ComboboxSize;
 }

--- a/packages/@luke-ui/react/src/combobox-field/primitive/input.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/input.tsx
@@ -14,8 +14,10 @@ import { useComboboxSize } from './size-context.js';
  *
  * @tier primitive
  */
-export interface ComboboxTextInputProps
-	extends DistributiveOmit<RacInputProps, 'className' | 'size'> {
+export interface ComboboxTextInputProps extends DistributiveOmit<
+	RacInputProps,
+	'className' | 'size'
+> {
 	className?: RacInputProps['className'];
 	size?: ComboboxSize;
 }

--- a/packages/@luke-ui/react/src/combobox-field/primitive/input.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/input.tsx
@@ -6,13 +6,8 @@ import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../../recipes/combobox.css.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import type { ComboboxSize } from './root.js';
 import { useComboboxSize } from './size-context.js';
-
-interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
-
-interface ComboboxStyleProps {
-	size?: ComboboxVariantProps['size'];
-}
 
 /**
  * Props for the styled combobox text input.
@@ -20,10 +15,9 @@ interface ComboboxStyleProps {
  * @tier primitive
  */
 export interface ComboboxTextInputProps
-	extends
-		DistributiveOmit<RacInputProps, 'className' | keyof ComboboxStyleProps>,
-		ComboboxStyleProps {
+	extends DistributiveOmit<RacInputProps, 'className' | 'size'> {
 	className?: RacInputProps['className'];
+	size?: ComboboxSize;
 }
 
 /** Text input used within `ComboboxControl` for combobox behavior. */

--- a/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
@@ -14,11 +14,8 @@ import * as styles from '../../recipes/combobox.css.js';
 import { COMBOBOX_ICON_SIZE } from '../../sizing/combobox-sizing.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import type { ComboboxSize } from './root.js';
 import { useComboboxSize } from './size-context.js';
-
-interface ComboboxStyleProps {
-	size?: 'small' | 'medium';
-}
 
 /**
  * Props for a combobox list item.
@@ -26,8 +23,9 @@ interface ComboboxStyleProps {
  * @tier primitive
  */
 export interface ComboboxItemProps<T extends object>
-	extends DistributiveOmit<RacListBoxItemProps<T>, 'className'>, ComboboxStyleProps {
+	extends DistributiveOmit<RacListBoxItemProps<T>, 'className'> {
 	className?: RacListBoxItemProps<T>['className'];
+	size?: ComboboxSize;
 }
 
 export function ComboboxItem<T extends object>(props: ComboboxItemProps<T>): JSX.Element {
@@ -66,8 +64,9 @@ export function ComboboxItem<T extends object>(props: ComboboxItemProps<T>): JSX
  * @tier primitive
  */
 export interface ComboboxLoadMoreItemProps
-	extends DistributiveOmit<RacListBoxLoadMoreItemProps, 'className'>, ComboboxStyleProps {
+	extends DistributiveOmit<RacListBoxLoadMoreItemProps, 'className'> {
 	className?: RacListBoxLoadMoreItemProps['className'];
+	size?: ComboboxSize;
 }
 
 export function ComboboxLoadMoreItem(props: ComboboxLoadMoreItemProps): JSX.Element {

--- a/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/item.tsx
@@ -22,8 +22,10 @@ import { useComboboxSize } from './size-context.js';
  *
  * @tier primitive
  */
-export interface ComboboxItemProps<T extends object>
-	extends DistributiveOmit<RacListBoxItemProps<T>, 'className'> {
+export interface ComboboxItemProps<T extends object> extends DistributiveOmit<
+	RacListBoxItemProps<T>,
+	'className'
+> {
 	className?: RacListBoxItemProps<T>['className'];
 	size?: ComboboxSize;
 }
@@ -63,8 +65,10 @@ export function ComboboxItem<T extends object>(props: ComboboxItemProps<T>): JSX
  *
  * @tier primitive
  */
-export interface ComboboxLoadMoreItemProps
-	extends DistributiveOmit<RacListBoxLoadMoreItemProps, 'className'> {
+export interface ComboboxLoadMoreItemProps extends DistributiveOmit<
+	RacListBoxLoadMoreItemProps,
+	'className'
+> {
 	className?: RacListBoxLoadMoreItemProps['className'];
 	size?: ComboboxSize;
 }

--- a/packages/@luke-ui/react/src/combobox-field/primitive/trigger.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/trigger.tsx
@@ -7,13 +7,8 @@ import * as styles from '../../recipes/combobox.css.js';
 import { COMBOBOX_ICON_SIZE } from '../../sizing/combobox-sizing.js';
 import type { DistributiveOmit } from '../../types/distributive-omit.js';
 import { cx } from '../../utils/index.js';
+import type { ComboboxSize } from './root.js';
 import { useComboboxSize } from './size-context.js';
-
-interface ComboboxVariantProps extends NonNullable<styles.ComboboxVariants> {}
-
-interface ComboboxStyleProps {
-	size?: ComboboxVariantProps['size'];
-}
 
 /**
  * Props for the combobox trigger button.
@@ -21,8 +16,9 @@ interface ComboboxStyleProps {
  * @tier primitive
  */
 export interface ComboboxTriggerProps
-	extends DistributiveOmit<RacButtonProps, 'className'>, ComboboxStyleProps {
+	extends DistributiveOmit<RacButtonProps, 'className'> {
 	className?: RacButtonProps['className'];
+	size?: ComboboxSize;
 }
 
 /** Trigger button used by combobox pattern. */

--- a/packages/@luke-ui/react/src/combobox-field/primitive/trigger.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/primitive/trigger.tsx
@@ -15,8 +15,7 @@ import { useComboboxSize } from './size-context.js';
  *
  * @tier primitive
  */
-export interface ComboboxTriggerProps
-	extends DistributiveOmit<RacButtonProps, 'className'> {
+export interface ComboboxTriggerProps extends DistributiveOmit<RacButtonProps, 'className'> {
 	className?: RacButtonProps['className'];
 	size?: ComboboxSize;
 }


### PR DESCRIPTION
Five combobox primitives each declared local types (ComboboxVariantProps, ComboboxStyleProps) to thread the size prop. This replaces the local types with size?: ComboboxSize imported from root.js.

item.tsx had inlined size?: 'small' | 'medium', which had drifted from the canonical type. It now uses ComboboxSize like the rest.

Files changed: control.tsx, input.tsx, trigger.tsx, clear-button.tsx, item.tsx.