### PR TITLE
Let composeField own the field slot interface

### DIFF
--- a/packages/@luke-ui/react/src/combobox-field/index.tsx
+++ b/packages/@luke-ui/react/src/combobox-field/index.tsx
@@ -1,9 +1,8 @@
-import type { CSSProperties, JSX, ReactNode } from 'react';
+import type { CSSProperties, JSX } from 'react';
 import type { ComboBoxProps as RacComboBoxProps } from 'react-aria-components/ComboBox';
 import { composeField } from '../field/compose-field.js';
-import type { FieldErrorProps } from '../field/primitive/error.js';
+import type { FieldSlotProps } from '../field/compose-field.js';
 import { Field } from '../field/primitive/index.js';
-import type { FieldNecessityIndicator } from '../field/primitive/label.js';
 import { Icon } from '../icon/index.js';
 import { LoadingSpinner } from '../loading-spinner/index.js';
 import type { DistributiveOmit } from '../types/distributive-omit.js';
@@ -38,18 +37,10 @@ interface ComboboxFieldRedeclaredRACProps {
 export interface ComboboxFieldProps<T extends object>
 	extends
 		DistributiveOmit<ComboboxInputProps<T>, 'children' | keyof ComboboxFieldRedeclaredRACProps>,
-		ComboboxFieldRedeclaredRACProps {
+		ComboboxFieldRedeclaredRACProps,
+		FieldSlotProps {
 	/** Item content for the listbox (render prop or static children). */
 	children: ComboboxListBoxProps<T>['children'];
-
-	/** Helper text shown below the control. */
-	description?: ReactNode;
-
-	/** Error content passed to `FieldError`. */
-	errorMessage?: FieldErrorProps['children'];
-
-	/** Label content shown above the control. */
-	label?: ReactNode;
 
 	/** Props forwarded to the inner listbox. */
 	listBoxProps?: DistributiveOmit<ComboboxListBoxProps<T>, 'children' | 'items' | 'loadMoreItem'>;
@@ -62,9 +53,6 @@ export interface ComboboxFieldProps<T extends object>
 
 	/** Width applied to the popover menu. */
 	menuWidth?: CSSProperties['width'];
-
-	/** Label necessity style. @default 'icon' */
-	necessityIndicator?: FieldNecessityIndicator;
 
 	/** Called when the listbox reaches its load-more sentinel. */
 	onLoadMore?: ComboboxLoadMoreItemProps['onLoadMore'];

--- a/packages/@luke-ui/react/src/field/compose-field.ts
+++ b/packages/@luke-ui/react/src/field/compose-field.ts
@@ -9,7 +9,7 @@ export interface FieldSlotProps {
 	errorMessage?: FieldErrorProps['children'];
 	/** Label content shown above the control. */
 	label?: ReactNode;
-	/** Label necessity style. */
+	/** Label necessity style. @default 'icon' */
 	necessityIndicator?: FieldNecessityIndicator;
 }
 

--- a/packages/@luke-ui/react/src/field/primitive/index.tsx
+++ b/packages/@luke-ui/react/src/field/primitive/index.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps, JSX, ReactNode } from 'react';
+import type { FieldSlotProps } from '../compose-field.js';
 import type { FieldDescriptionProps } from './description.js';
 import { FieldDescription } from './description.js';
 import type { FieldErrorProps } from './error.js';
@@ -17,16 +18,8 @@ type PrimitiveFieldProps = ComponentProps<typeof PrimitiveField>;
  *
  * @tier primitive
  */
-export interface FieldProps extends Omit<PrimitiveFieldProps, 'children'> {
+export interface FieldProps extends Omit<PrimitiveFieldProps, 'children'>, FieldSlotProps {
 	children: ReactNode;
-	/** Optional helper text shown below the input. */
-	description?: ReactNode;
-	/** Error content passed to `FieldError`. */
-	errorMessage?: FieldErrorProps['children'];
-	/** Label content shown above the input. */
-	label?: ReactNode;
-	/** Label necessity style. Defaults to `'icon'`. */
-	necessityIndicator?: FieldNecessityIndicator;
 }
 
 /** Composes label, control slot, description, and error text. */

--- a/packages/@luke-ui/react/src/text-field/index.tsx
+++ b/packages/@luke-ui/react/src/text-field/index.tsx
@@ -5,9 +5,8 @@ import type {
 } from 'react-aria-components/TextField';
 import { TextField as RacTextField } from 'react-aria-components/TextField';
 import { composeField } from '../field/compose-field.js';
-import type { FieldErrorProps } from '../field/primitive/error.js';
+import type { FieldSlotProps } from '../field/compose-field.js';
 import { Field } from '../field/primitive/index.js';
-import type { FieldNecessityIndicator } from '../field/primitive/label.js';
 import type { TextInputSize } from './primitive/index.js';
 import { TextInput } from './primitive/index.js';
 
@@ -34,21 +33,14 @@ interface TextFieldRedeclaredRACProps {
 export interface TextFieldProps
 	extends
 		Omit<RacTextFieldProps, 'children' | 'size' | keyof TextFieldRedeclaredRACProps>,
-		TextFieldRedeclaredRACProps {
+		TextFieldRedeclaredRACProps,
+		FieldSlotProps {
 	/** Element shown after the input value. */
 	adornmentEnd?: ReactNode;
 	/** Element shown before the input value. */
 	adornmentStart?: ReactNode;
-	/** Helper text shown below the control. */
-	description?: ReactNode;
-	/** Error content passed to `FieldError`. */
-	errorMessage?: FieldErrorProps['children'];
 	/** Class name forwarded to the inner input element. */
 	inputClassName?: RacInputProps['className'];
-	/** Label content shown above the input. */
-	label?: ReactNode;
-	/** Label necessity style. */
-	necessityIndicator?: FieldNecessityIndicator;
 	/** Placeholder text for the input. */
 	placeholder?: string;
 	/** Control size. Defaults to `'medium'`. */


### PR DESCRIPTION
Four prop interfaces each hand-typed the same label/description/errorMessage/necessityIndicator quartet. This makes FieldProps, TextFieldProps, and ComboboxFieldProps all extend FieldSlotProps from compose-field.ts, so the slot interface and its runtime split travel together.

The necessityIndicator default JSDoc moves to FieldSlotProps. Three unused imports removed.

- field/primitive/index.tsx: -4 inline prop declarations
- text-field/index.tsx: -4 inline prop declarations, -2 unused imports
- combobox-field/index.tsx: -4 inline prop declarations, -3 unused imports