### PR TITLE
Extract shared documented RAC prop types

### DIFF
--- a/packages/@luke-ui/react/src/button/index.tsx
+++ b/packages/@luke-ui/react/src/button/index.tsx
@@ -1,10 +1,10 @@
 import type { JSX, ReactNode } from 'react';
-import type { ButtonProps as RacButtonProps } from 'react-aria-components/Button';
 import { LoadingSpinner } from '../loading-spinner/index.js';
 import * as styles from '../recipes/button-composed.css.js';
 import type * as primitiveStyles from '../recipes/button.css.js';
 import { BUTTON_FONT_SIZE } from '../sizing/button-sizing.js';
 import { Text } from '../text/index.js';
+import type { DocumentedPressProps } from '../types/documented-rac-props.js';
 import type { ButtonProps as PrimitiveButtonProps } from './primitive/index.js';
 import { Button as PrimitiveButton } from './primitive/index.js';
 
@@ -43,18 +43,6 @@ interface ButtonStyleProps {
 	tone?: PrimitiveButtonVariantProps['tone'];
 }
 
-interface ButtonRedeclaredRACProps {
-	/**
-	 * Whether the button is disabled. Disabled buttons can't be focused or pressed.
-	 * @default false
-	 */
-	isDisabled?: RacButtonProps['isDisabled'];
-	/** Press handler. Called on click, Enter, or Space. */
-	onPress?: RacButtonProps['onPress'];
-	/** HTML button type. */
-	type?: RacButtonProps['type'];
-}
-
 /**
  * Composed button with size, tone, pending, and block variants.
  *
@@ -62,9 +50,9 @@ interface ButtonRedeclaredRACProps {
  */
 export interface ButtonProps
 	extends
-		Omit<PrimitiveButtonProps, keyof ButtonStyleProps | keyof ButtonRedeclaredRACProps>,
+		Omit<PrimitiveButtonProps, keyof ButtonStyleProps | keyof DocumentedPressProps>,
 		ButtonStyleProps,
-		ButtonRedeclaredRACProps {}
+		DocumentedPressProps {}
 
 /** Composed button. Wraps children in a `Text` for ellipsis truncation. Shows a spinner when `isPending`. */
 export function Button(props: ButtonProps): JSX.Element {

--- a/packages/@luke-ui/react/src/icon-button/index.tsx
+++ b/packages/@luke-ui/react/src/icon-button/index.tsx
@@ -1,11 +1,11 @@
 import type { JSX } from 'react';
-import type { ButtonProps as RacButtonProps } from 'react-aria-components/Button';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import type { ButtonProps as PrimitiveButtonProps } from '../button/primitive/index.js';
 import { Button } from '../button/primitive/index.js';
 import type { IconName } from '../icon/index.js';
 import { Icon } from '../icon/index.js';
 import * as styles from '../recipes/icon-button.css.js';
+import type { DocumentedPressProps } from '../types/documented-rac-props.js';
 import { cx } from '../utils/index.js';
 
 interface IconButtonVariantProps extends NonNullable<styles.IconButtonVariants> {}
@@ -18,18 +18,6 @@ interface IconButtonStyleProps {
 	size?: IconButtonVariantProps['size'];
 }
 
-interface IconButtonRedeclaredRACProps {
-	/**
-	 * Whether the button is disabled. Disabled buttons can't be focused or pressed.
-	 * @default false
-	 */
-	isDisabled?: RacButtonProps['isDisabled'];
-	/** Press handler. Called on click, Enter, or Space. */
-	onPress?: RacButtonProps['onPress'];
-	/** HTML button type. */
-	type?: RacButtonProps['type'];
-}
-
 /**
  * Props for `IconButton`.
  *
@@ -37,9 +25,9 @@ interface IconButtonRedeclaredRACProps {
  */
 export interface IconButtonProps
 	extends
-		Omit<PrimitiveButtonProps, keyof IconButtonStyleProps | keyof IconButtonRedeclaredRACProps>,
+		Omit<PrimitiveButtonProps, keyof IconButtonStyleProps | keyof DocumentedPressProps>,
 		IconButtonStyleProps,
-		IconButtonRedeclaredRACProps {
+		DocumentedPressProps {
 	/** Icon name from the generated icon set. */
 	icon: IconName;
 }

--- a/packages/@luke-ui/react/src/link/index.tsx
+++ b/packages/@luke-ui/react/src/link/index.tsx
@@ -3,6 +3,7 @@ import type { LinkProps as RacLinkProps } from 'react-aria-components/Link';
 import { Link as RacLink } from 'react-aria-components/Link';
 import { composeRenderProps } from 'react-aria-components/composeRenderProps';
 import * as styles from '../recipes/link.css.js';
+import type { DocumentedLinkProps } from '../types/documented-rac-props.js';
 import { cx } from '../utils/index.js';
 
 interface LinkVariantProps extends NonNullable<styles.LinkVariants> {}
@@ -14,16 +15,6 @@ interface LinkStyleProps {
 	tone?: LinkVariantProps['tone'];
 }
 
-interface LinkRedeclaredRACProps {
-	/** URL the link points to. */
-	href?: RacLinkProps['href'];
-	/**
-	 * Whether the link is disabled. Disabled links can't be focused or activated.
-	 * @default false
-	 */
-	isDisabled?: RacLinkProps['isDisabled'];
-}
-
 /**
  * Props for the primitive link.
  *
@@ -31,9 +22,9 @@ interface LinkRedeclaredRACProps {
  */
 export interface LinkProps
 	extends
-		Omit<RacLinkProps, keyof LinkStyleProps | keyof LinkRedeclaredRACProps>,
+		Omit<RacLinkProps, keyof LinkStyleProps | keyof DocumentedLinkProps>,
 		LinkStyleProps,
-		LinkRedeclaredRACProps {}
+		DocumentedLinkProps {}
 
 /** Styled link. */
 export function Link(props: LinkProps): JSX.Element {

--- a/packages/@luke-ui/react/src/text-field/index.tsx
+++ b/packages/@luke-ui/react/src/text-field/index.tsx
@@ -7,23 +7,9 @@ import { TextField as RacTextField } from 'react-aria-components/TextField';
 import { composeField } from '../field/compose-field.js';
 import type { FieldSlotProps } from '../field/compose-field.js';
 import { Field } from '../field/primitive/index.js';
+import type { DocumentedInputProps } from '../types/documented-rac-props.js';
 import type { TextInputSize } from './primitive/index.js';
 import { TextInput } from './primitive/index.js';
-
-interface TextFieldRedeclaredRACProps {
-	/** Initial value (uncontrolled). */
-	defaultValue?: RacTextFieldProps['defaultValue'];
-	/** Whether the field is disabled. */
-	isDisabled?: RacTextFieldProps['isDisabled'];
-	/** Whether the field has a validation error. */
-	isInvalid?: RacTextFieldProps['isInvalid'];
-	/** Whether the field is read-only. */
-	isReadOnly?: RacTextFieldProps['isReadOnly'];
-	/** Called when the value changes. */
-	onChange?: RacTextFieldProps['onChange'];
-	/** Controlled input value. */
-	value?: RacTextFieldProps['value'];
-}
 
 /**
  * Props for the composed text field.
@@ -32,8 +18,8 @@ interface TextFieldRedeclaredRACProps {
  */
 export interface TextFieldProps
 	extends
-		Omit<RacTextFieldProps, 'children' | 'size' | keyof TextFieldRedeclaredRACProps>,
-		TextFieldRedeclaredRACProps,
+		Omit<RacTextFieldProps, 'children' | 'size' | keyof DocumentedInputProps>,
+		DocumentedInputProps,
 		FieldSlotProps {
 	/** Element shown after the input value. */
 	adornmentEnd?: ReactNode;

--- a/packages/@luke-ui/react/src/types/documented-rac-props.ts
+++ b/packages/@luke-ui/react/src/types/documented-rac-props.ts
@@ -1,0 +1,40 @@
+import type { ButtonProps as RacButtonProps } from 'react-aria-components/Button';
+import type { LinkProps as RacLinkProps } from 'react-aria-components/Link';
+import type { TextFieldProps as RacTextFieldProps } from 'react-aria-components/TextField';
+
+export interface DocumentedPressProps {
+	/**
+	 * Whether the button is disabled. Disabled buttons can't be focused or pressed.
+	 * @default false
+	 */
+	isDisabled?: RacButtonProps['isDisabled'];
+	/** Press handler. Called on click, Enter, or Space. */
+	onPress?: RacButtonProps['onPress'];
+	/** HTML button type. */
+	type?: RacButtonProps['type'];
+}
+
+export interface DocumentedLinkProps {
+	/** URL the link points to. */
+	href?: RacLinkProps['href'];
+	/**
+	 * Whether the link is disabled. Disabled links can't be focused or activated.
+	 * @default false
+	 */
+	isDisabled?: RacLinkProps['isDisabled'];
+}
+
+export interface DocumentedInputProps {
+	/** Initial value (uncontrolled). */
+	defaultValue?: RacTextFieldProps['defaultValue'];
+	/** Whether the field is disabled. */
+	isDisabled?: RacTextFieldProps['isDisabled'];
+	/** Whether the field has a validation error. */
+	isInvalid?: RacTextFieldProps['isInvalid'];
+	/** Whether the field is read-only. */
+	isReadOnly?: RacTextFieldProps['isReadOnly'];
+	/** Called when the value changes. */
+	onChange?: RacTextFieldProps['onChange'];
+	/** Controlled input value. */
+	value?: RacTextFieldProps['value'];
+}


### PR DESCRIPTION
Button, IconButton, Link, TextField each had a local *RedeclaredRACProps interface with hand-copied JSDoc for isDisabled, onPress, type, etc. Five copies, already drifting (link's isDisabled said 'activated' instead of 'pressed').

This creates src/shared-rac-props/index.ts with three mixins:
- DocumentedPressProps (button, icon-button)
- DocumentedLinkProps (link)
- DocumentedInputProps (text-field)

Each component deletes its local interface and extends the shared mixin instead. ComboboxField keeps its local interface because its value type (Key | null) doesn't match DocumentedInputProps (string).

4 components touched, ~50 lines removed, one JSDoc source per prop.