### PR TITLE
Route tier and group taxonomy through the catalog

### DIFF
--- a/packages/@luke-ui/docs-tools/src/package-docs-catalog.ts
+++ b/packages/@luke-ui/docs-tools/src/package-docs-catalog.ts
@@ -50,6 +50,18 @@ export type PackageDocsCatalogEntry =
 	| PackageDocsComponentEntry
 	| PackageDocsBarrelEntry;
 
+export const DOC_GROUPS = ['actions', 'feedback', 'forms', 'typography', 'visuals'] as const;
+export type DocGroup = (typeof DOC_GROUPS)[number];
+
+export type TierBucket = 'atom' | 'composed' | 'primitive' | 'barrel' | 'asset';
+
+export function tierBucket(entry: { shape: string; tier: string }): TierBucket {
+	if (entry.shape === 'asset' || entry.shape === 'barrel') return entry.shape;
+	if (entry.tier === 'atom') return 'atom';
+	if (entry.tier === 'primitive') return 'primitive';
+	return 'composed';
+}
+
 export type PackageDocsCatalogMetadata = Pick<
 	PackageDocsCatalogEntry,
 	'path' | 'target' | 'slug' | 'shape' | 'pageKind' | 'tier' | 'title' | 'description'
@@ -103,7 +115,13 @@ function resolveEntry(entry: DiscoveredExport): PackageDocsCatalogEntry {
 	}
 
 	const parsed = parseComponent(entry.sourcePath);
-	const tier = parsed.tier ?? entry.tier;
+	if (!parsed.tier) {
+		throw new Error(
+			`Export "${entry.path}" is missing a @tier JSDoc tag. ` +
+				`Add /** @tier atom */ or /** @tier composed */ to its props interface.`,
+		);
+	}
+	const tier = parsed.tier;
 	return {
 		...entry,
 		description: parsed.description,

--- a/packages/@luke-ui/docs-tools/src/render-index.ts
+++ b/packages/@luke-ui/docs-tools/src/render-index.ts
@@ -1,4 +1,5 @@
 import type { PackageDocsCatalogMetadata } from './package-docs-catalog.js';
+import { tierBucket } from './package-docs-catalog.js';
 
 export interface IndexEntry extends PackageDocsCatalogMetadata {
 	href?: string;
@@ -29,16 +30,19 @@ export function renderIndex(input: RenderIndexInput): string {
 	const assets: Array<IndexEntry> = [];
 
 	for (const e of entries) {
-		if (e.shape === 'component') {
-			if (e.tier === 'primitive') {
+		switch (tierBucket(e)) {
+			case 'primitive':
 				primitives.push(e);
-			} else {
+				break;
+			case 'barrel':
+				barrels.push(e);
+				break;
+			case 'asset':
+				assets.push(e);
+				break;
+			default:
 				primary.push(e);
-			}
-		} else if (e.shape === 'barrel') {
-			barrels.push(e);
-		} else if (e.shape === 'asset') {
-			assets.push(e);
+				break;
 		}
 	}
 

--- a/packages/@luke-ui/docs-tools/src/render-llms-full.ts
+++ b/packages/@luke-ui/docs-tools/src/render-llms-full.ts
@@ -1,4 +1,5 @@
 import type { PackageDocsCatalogMetadata } from './package-docs-catalog.js';
+import { tierBucket } from './package-docs-catalog.js';
 
 export interface LlmsFullEntry extends Pick<PackageDocsCatalogMetadata, 'slug' | 'shape' | 'tier'> {
 	md: string;
@@ -31,33 +32,19 @@ export function renderLlmsFull(entries: Array<LlmsFullEntry>): string {
  * Entries that don't classify into a bucket are dropped.
  */
 export function sortLlmsFullEntries<T extends LlmsFullEntry>(entries: Array<T>): Array<T> {
-	const buckets: Record<LlmsFullBucket, Array<T>> = {
-		atom: [],
-		barrel: [],
-		composed: [],
-		primitive: [],
-	};
+	const buckets: Record<string, Array<T>> = {};
 	for (const entry of entries) {
-		const bucket = bucketFor(entry);
-		if (bucket) buckets[bucket].push(entry);
+		if (entry.shape !== 'component' && entry.shape !== 'barrel') continue;
+		if (entry.shape === 'component' && !entry.tier) continue;
+
+		const bucket = tierBucket(entry);
+		(buckets[bucket] ??= []).push(entry);
 	}
 	const bySlug = (a: T, b: T) => a.slug.localeCompare(b.slug);
 	return [
-		...buckets.atom.sort(bySlug),
-		...buckets.composed.sort(bySlug),
-		...buckets.barrel.sort(bySlug),
-		...buckets.primitive.sort(bySlug),
+		...(buckets.atom ?? []).sort(bySlug),
+		...(buckets.composed ?? []).sort(bySlug),
+		...(buckets.barrel ?? []).sort(bySlug),
+		...(buckets.primitive ?? []).sort(bySlug),
 	];
-}
-
-type LlmsFullBucket = 'atom' | 'composed' | 'barrel' | 'primitive';
-
-function bucketFor(entry: LlmsFullEntry): LlmsFullBucket | undefined {
-	if (entry.shape === 'barrel') return 'barrel';
-	if (entry.shape !== 'component') return;
-
-	if (entry.tier === 'atom') return 'atom';
-	if (entry.tier === 'primitive') return 'primitive';
-	if (entry.tier === 'composed') return 'composed';
-	return;
 }

--- a/packages/turbo-generators/config.ts
+++ b/packages/turbo-generators/config.ts
@@ -1,16 +1,15 @@
+import { DOC_GROUPS } from '@luke-ui/docs-tools/package-docs-catalog';
 import type { PlopTypes } from '@turbo/gen';
 import * as z from 'zod';
 import { applyComponentCreationPlan } from './src/apply-component-creation-plan.js';
 import type { CreateComponentInput } from './src/component-creation-plan.js';
 import { createComponentPlan } from './src/component-creation-plan.js';
-
-const DOCS_GROUPS = ['actions', 'feedback', 'forms', 'typography', 'visuals'] as const;
 const COMPONENT_NAME_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
 const COMPONENT_TIERS = ['atom', 'composed'] as const;
 const COMPONENT_STYLING = ['none', 'recipe'] as const;
 
 const componentAnswersSchema = z.object({
-	docsGroup: z.enum(DOCS_GROUPS),
+	docsGroup: z.enum(DOC_GROUPS),
 	name: z.string().min(1),
 	styling: z.enum(COMPONENT_STYLING),
 	tier: z.enum(COMPONENT_TIERS),
@@ -44,7 +43,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 				type: 'list',
 			},
 			{
-				choices: [...DOCS_GROUPS],
+				choices: [...DOC_GROUPS],
 				message: 'Docs group:',
 				name: 'docsGroup',
 				type: 'list',

--- a/packages/turbo-generators/package.json
+++ b/packages/turbo-generators/package.json
@@ -10,6 +10,9 @@
 		"generate:component": "tsx scripts/generate-component.ts",
 		"test": "vp test run"
 	},
+	"dependencies": {
+		"@luke-ui/docs-tools": "workspace:*"
+	},
 	"devDependencies": {
 		"@types/node": "catalog:",
 		"tsx": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,10 @@ importers:
         version: 4.4.3
 
   packages/turbo-generators:
+    dependencies:
+      '@luke-ui/docs-tools':
+        specifier: workspace:*
+        version: link:../@luke-ui/docs-tools
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Pulls three pieces of taxonomy knowledge out of ad-hoc locations and into
the single package-docs catalog where they belong:

- **DOC_GROUPS**: The docs group set (`actions | feedback | forms | typography | visuals`) was
  defined in `turbo-generators/config.ts` and duplicated in `meta.json`. Now it lives in
  `package-docs-catalog.ts` and `config.ts` imports it from there.
- **tierBucket()**: `renderIndex` and `sortLlmsFullEntries` each maintained their own logic
  for classifying entries into sections. Now both call the shared `tierBucket()` from the catalog.
- **`@tier` validation**: `resolveEntry` now throws when a component export has no `@tier` tag.
  Previously a missing tag silently defaulted to `'composed'`, making it impossible to tell
  an intentional composed component from one that simply forgot the tag.
